### PR TITLE
bugfix for Parser::MST on Windows: <CR> character in the last afun on…

### DIFF
--- a/lib/Treex/Tool/Parser/MST.pm
+++ b/lib/Treex/Tool/Parser/MST.pm
@@ -161,13 +161,22 @@ sub process {
         else {
             my ($afuns_string, $parents_string);
             if ($self->version eq '0.4.3b-AdaptedCzech'){
-                chomp ($parents_string = <$reader>);
-                chomp ($afuns_string   = <$reader>);
+
+                $parents_string = <$reader>;
+                $parents_string =~ s/\R$//;
+
+                $afuns_string = <$reader>;
+                $afuns_string =~ s/\R$//;
+                
             } else {
                 <$reader>;    # forms
                 <$reader>;    # pos
-                chomp ($afuns_string   = <$reader>);
-                chomp ($parents_string = <$reader>);
+                
+                $afuns_string = <$reader>;
+                $afuns_string =~ s/\R$//;
+
+                $parents_string = <$reader>;
+                $parents_string =~ s/\R$//;
             }
             
             log_fatal "Treex::Tool::Parser::MST wrote unexpected number of lines" if !defined $afuns_string || !defined $parents_string;


### PR DESCRIPTION
As discussed on the mailing list.

This is the Martin Popel's solution that worked for me.