### PR TITLE
Fix undef warning in T2A::PT::PrepositionContraction

### DIFF
--- a/lib/Treex/Block/T2A/PT/PrepositionContraction.pm
+++ b/lib/Treex/Block/T2A/PT/PrepositionContraction.pm
@@ -122,8 +122,6 @@ sub process_zone {
     my ( $self, $zone ) = @_;
     my $a_root   = $zone->get_atree();
 
-    $a_root->get_descendants( { ordered => 1 } );
-
     my $last_node;
     foreach my $node ( $a_root->get_descendants({ ordered => 1 }) ) {
 
@@ -134,7 +132,7 @@ sub process_zone {
                 my $first_form = $last_node->form;
                 $first_form =~ s/_//g;
 
-                my $contraction = $CONTRACTION{(lc $first_form) . " " . (lc $node->form)};
+                my $contraction = $CONTRACTION{(lc $first_form) . ' ' . (lc $node->form)};
 
                 if(defined $contraction){
 
@@ -145,8 +143,8 @@ sub process_zone {
                         $last_node->set_form($contraction);
                     }
 
-                    $node->set_form(undef);
-                    $node->set_lemma(undef);
+                    $node->set_form('');
+                    $node->set_lemma('');
 
                 }
             }
@@ -154,6 +152,7 @@ sub process_zone {
 
         $last_node = $node;
     }
+    return;
 }
 
 


### PR DESCRIPTION
@joaoantonioverdade or @luismsgomes:
This is just a minor issue.

`$node->set_form(undef)` creates many undef warnings,
one of them was in this very block when checking
`$last_node->form =~ /^[[:alpha:]]+$/`

Setting form (or lemma) to an empty string (or undef) is a hack,
which may lead to strange problems (though now I am not aware of any).
Deleting the node, seems to be a more elegant solution.