### PR TITLE
Interset 2.049 fixes a bug in feature value for comparative

### DIFF
--- a/lib/Treex/Block/T2A/InitMorphcat.pm
+++ b/lib/Treex/Block/T2A/InitMorphcat.pm
@@ -12,7 +12,7 @@ my %gram2iset = (
     'definiteness=reduced'    => 'definiteness=red',
 
     'degcmp=pos'  => 'degree=pos',
-    'degcmp=comp' => 'degree=comp',
+    'degcmp=comp' => 'degree=cmp',
     'degcmp=sup'  => 'degree=sup',
 
     'diathesis=pas' => 'voice=pass',
@@ -89,7 +89,7 @@ sub process_tnode {
     my $gender = $t_node->gram_gender || '';
     if ( $gender eq 'inan' ) {
         $a_node->iset->set_animateness('inan');
-    }    
+    }
 
     # The type of pronoun is not preserved on t-layer, but at least we know it is a pronoun
     if ( ( $t_node->gram_sempos // '' ) =~ /pron/ ) {
@@ -107,15 +107,15 @@ sub process_tnode {
             $a_node->iset->set_person('');
         }
     }
-    
+
     # Fill grammatemes through coref_gram.rf for reflexive pronouns
     if ( $t_node->t_lemma eq '#PersPron' and ( my ($t_antec) = $t_node->get_coref_gram_nodes() ) ){
         while ( $t_antec->get_coref_gram_nodes() ){
             ($t_antec) = $t_antec->get_coref_gram_nodes();  # go to the beginng of the coreference chain
         }
-        my $antec_gram = $t_antec->get_attr('gram') or return; 
+        my $antec_gram = $t_antec->get_attr('gram') or return;
         $self->fill_iset_from_gram( $t_node, $a_node, $antec_gram );
-        $a_node->iset->set_reflex('reflex');    
+        $a_node->iset->set_reflex('reflex');
     }
 
     return;
@@ -127,7 +127,7 @@ sub should_fill {
 
 sub fill_iset_from_gram {
     my ( $self, $t_node, $a_node, $grammatemes_rf ) = @_;
-    
+
     while ( my ( $name, $value ) = each %{$grammatemes_rf} ) {
         if ( defined $value && $self->should_fill( $name, $t_node ) && ( my $iset_rule = $gram2iset{"$name=$value"} ) ) {
             my ( $i_name, $i_value ) = split /=/, $iset_rule;
@@ -142,7 +142,7 @@ __END__
 
 =encoding utf-8
 
-=head1 NAME 
+=head1 NAME
 
 Treex::Block::T2A::InitMorphcat
 

--- a/lib/Treex/Block/Write/ADTXML.pm
+++ b/lib/Treex/Block/Write/ADTXML.pm
@@ -200,8 +200,8 @@ sub _get_pos {
     }
     if ( $pos eq 'adj' ) {
         $data{'aform'} = 'base'   if ( $anode->match_iset( 'degree' => 'pos' ) );
-        $data{'aform'} = 'compar' if ( $anode->match_iset( 'degree' => 'comp' ) );
-        $data{'aform'} = 'super'  if ( $anode->match_iset( 'degree' => 'sup' ) );
+        $data{'aform'} = 'compar' if ( $anode->is_comparative() );
+        $data{'aform'} = 'super'  if ( $anode->is_superlative() );
     }
 
     return join( ' ', map { $_ . '="' . $data{$_} . '"' } sort { $a cmp $b } keys %data );

--- a/lib/Treex/Core/Node/Interset.pm
+++ b/lib/Treex/Core/Node/Interset.pm
@@ -9,7 +9,7 @@ parameter interset_attribute => (
 
 use Treex::Core::Log;
 use List::Util qw(first); # TODO: this wouldn't be needed if there was Treex::Core::Common for roles
-use Lingua::Interset 2.047;
+use Lingua::Interset 2.050;
 use Lingua::Interset::FeatureStructure;
 use Data::Dumper;
 


### PR DESCRIPTION
Interset used "comp", Universal Features use "Cmp". New Interset uses "cmp" (capitalization is done automatically but the "o" caused the output to be incompatible. There might be other places in Treex, of which I am not aware and where this change must be reflected once the new Interset is installed.