### PR TITLE
Fix for a very rare crash of FixAtree

### DIFF
--- a/lib/Treex/Block/W2A/EN/FixAtree.pm
+++ b/lib/Treex/Block/W2A/EN/FixAtree.pm
@@ -203,6 +203,10 @@ sub fix_node {
         #   "Which(parent=failed) students failed?"
         if ( $p_tag =~ /^(V|MD)/ && $node->precedes($parent) ) {
             if ( $ord == 1 && $grandpa->is_root() && $last_form eq '?' && $next_tag =~ /^N/ ) {
+                # Very rare case: "WHich(parent=watch) BBC(parent=WHich) do you watch?" 
+                if ($next_node->parent == $node){
+                    $next_node->set_parent($parent);
+                }
                 $node->set_parent($next_node);
             }
             return;


### PR DESCRIPTION
For the sentence "WHich BBC do you watch?" (occurs in WMT15 News
discussions), the tagger and parser results look like this:

```
    WHich   tag=IN  parent=watch
    BBC     tag=NNP parent=WHich
    ...
```

The previous implementation would cause a cycle in that case.
This fixes the cycle, but does not attempt to fix the messed up POS
tagging.