### PR TITLE
Fixing T2A::EN::AddArticles

### DIFF
--- a/lib/Treex/Block/A2N/CS/FixNERforIT.pm
+++ b/lib/Treex/Block/A2N/CS/FixNERforIT.pm
@@ -1,0 +1,52 @@
+package Treex::Block::A2N::CS::FixNERforIT;
+
+use Moose;
+use Treex::Core::Common;
+
+extends 'Treex::Core::Block';
+
+sub process_anode {
+    my ( $self, $anode ) = @_;
+
+    # must be an unknown lemma
+    return if ( !$anode->wild->{lemma_guessed} );
+    
+    # require uppercase letter in the middle of the sentence
+    return if ( $anode->form !~ /\p{Lu}/ or $anode->ord == 1 );
+
+    # skip those that already have an n-node
+    return if ( $anode->n_node() );
+    
+    my $ntree = $anode->get_zone->get_ntree();
+    my $nnode = $ntree->create_child({
+        ne_type => 'o_',
+        normalized_name => $anode->lemma,
+    });
+    $nnode->set_anodes($anode);
+    return;
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Treex::Block::A2N::CS::FixNERforIT
+
+=head1 DESCRIPTION
+
+Setting things with uppercase letters that are not in MorphoDiTa's dictionary
+as NEs of type "artefact".
+
+=head1 AUTHORS
+
+Ondřej Dušek <odusek@ufal.mff.cuni.cz>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright © 2015 by Institute of Formal and Applied Linguistics, Charles University in Prague
+
+This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Block/A2T/SetGrammatemes.pm
+++ b/lib/Treex/Block/A2T/SetGrammatemes.pm
@@ -49,6 +49,10 @@ my %iset2gram = (
     'number=plur' => 'number=pl',
     'number=dual' => 'number=du',
 
+    # possessive adjectives (overriding the adjectival number)
+    'possnumber=sing' => 'number=sg',
+    'possnumber=plur' => 'number=pl',
+
     'numtype=card' => 'numbertype=basic',
     'numtype=ord' => 'numbertype=ord',
     'numtype=frac' => 'numbertype=frac',

--- a/lib/Treex/Block/T2A/AddArticles.pm
+++ b/lib/Treex/Block/T2A/AddArticles.pm
@@ -9,6 +9,15 @@ has 'article_form' => ( isa => 'HashRef', is => 'ro', lazy_build => 1, builder =
 # To be overridden for each language
 sub _build_article_form { return {} }
 
+# Getting article key (that will identify it in the article_form table)
+sub _get_article_key {
+    my ( $self, $anode, $definiteness ) = @_;
+
+    my $gender = $anode->iset->gender // '';
+    my $number = $anode->iset->number // '';
+    return "$definiteness $gender $number";
+}
+
 sub process_tnode {
     my ( $self, $tnode ) = @_;
     my $anode = $tnode->get_lex_anode()   or return;
@@ -16,9 +25,7 @@ sub process_tnode {
 
     return if ( not $self->can_have_article( $tnode, $anode ) );
 
-    my $gender = $anode->iset->gender // '';
-    my $number = $anode->iset->number // '';
-    my $form = $self->article_form->{"$def $gender $number"} or return;
+    my $form = $self->article_form->{ $self->_get_article_key( $anode, $def ) } or return;
 
     my $article = $anode->create_child(
         {
@@ -33,7 +40,6 @@ sub process_tnode {
     $tnode->add_aux_anodes($article);
     return;
 }
-
 
 # To be overridden for each language
 sub can_have_article {

--- a/lib/Treex/Block/T2A/EN/AddArticles.pm
+++ b/lib/Treex/Block/T2A/EN/AddArticles.pm
@@ -21,11 +21,20 @@ override '_get_article_key' => sub {
     return "$definiteness $number";
 };
 
+my $PRONOUN = qr{
+    \#PersPron|
+    th(is|[oe]se|at)|
+    wh(at|ich|o(m|se)?)(ever)?|
+    (any|every|some|no)(body|one|thing)|each|n?either|(no[_ ])?one|
+    both|many|several|
+    all|any|most|none|some
+}xi;
+
 override 'can_have_article' => sub {
     my ( $self, $tnode, $anode ) = @_;
 
     # no articles possible/needed for indefinite pronouns
-    return 0 if ( $anode->is_pronoun and ( $tnode->gram_definiteness // '' ) eq 'indefinite' );
+    return 0 if ( $tnode->t_lemma =~ /^($PRONOUN)$/ );
     return 1;
 };
 

--- a/lib/Treex/Block/T2A/EN/AddArticles.pm
+++ b/lib/Treex/Block/T2A/EN/AddArticles.pm
@@ -1,306 +1,33 @@
 package Treex::Block::T2A::EN::AddArticles;
-use utf8;
+
 use Moose;
-use Moose::Util::TypeConstraints;
 use Treex::Core::Common;
-use Treex::Tool::Lexicon::EN::Countability;
-use Treex::Tool::Lexicon::EN::Hypernyms;
 
-extends 'Treex::Core::Block';
+extends 'Treex::Block::T2A::AddArticles';
 
-has 'grammateme_only' => ( isa => 'Bool', is => 'ro', default => 0 ); 
-
-has 'context_size' => ( isa => 'Int', is => 'ro', default => 7 );
-
-enum DiscourseBreaks => [qw/ document sentence /];
-has 'clear_context_after' => ( isa => 'DiscourseBreaks', is => 'ro', default => 'document' );
-
-has '_local_context' => ( isa => 'HashRef', is => 'rw', default => sub { {} } );
-
-after 'process_document' => sub {
-    my ($self) = @_;
-    if ($self->clear_context_after eq 'document') {
-        $self->_set_local_context( {} );    # clear local context after document
-    }
+override '_build_article_form' => sub {
+    return {
+        'definite S'   => 'the',
+        'definite P'   => 'the',
+        'indefinite S' => 'a',
+        'indefinite P' => '',
+    };
 };
 
-after 'process_bundle' => sub {
-    my ($self) = @_;
-    if ($self->clear_context_after eq 'sentence') {
-        $self->_set_local_context( {} );    # clear local context after each sentence
-    }
+override '_get_article_key' => sub {
+    my ( $self, $anode, $definiteness ) = @_;
+
+    my $number = ( $anode->morphcat_number || '.' ) ne '.' ? $anode->morphcat_number : 'S';
+    return "$definiteness $number";
 };
 
-sub process_tnode {
-
-    my ( $self, $tnode ) = @_;
-    my ($anode) = $tnode->get_lex_anode();
-
-    # rule out personal pronouns and generated nodes
-    return if ( $tnode->t_lemma =~ /^#/ );    # or ($tnode->functor // '') eq 'RSTR'
-    return if ( !$anode );
-    
-    # override rules and use just the gram_definiteness attribute
-    if ( $self->grammateme_only ){
-        if ($tnode->gram_definiteness){
-            my $article_anode = add_article_node( $anode, $tnode->gram_definiteness eq 'definite' ? 'the' : 'a' );
-            $tnode->add_aux_anodes($article_anode);
-        }
-        return;
-    }
-
-    # rule out non-nouns
-    return if ( ( $tnode->gram_sempos // '' ) !~ /^n/ and ( $anode->lemma // '' ) !~ /^(dozen|thousand|lot|deal)$/ );
-
-    $self->decide_article( $tnode, $anode );
-    return;
-}
-
-sub replace_some_with_indef {
-    my ($self, $tnode, $countability) = @_;
-
-    return if ($countability && $countability ne 'countable');
-    return if (!defined $tnode->gram_number || $tnode->gram_number ne 'sg');
-    my ($some_tnode) = grep {$_->t_lemma eq 'some'} $tnode->get_children;
-    return if (!defined $some_tnode);
-
-    my $some_anode = $some_tnode->get_lex_anode;
-
-    $some_tnode->remove({children=>'rehang'});
-    $some_anode->remove({children=>'rehang'});
-    $tnode->set_gram_definiteness('indefinite');
-}
-
-sub decide_article {
+override 'can_have_article' => sub {
     my ( $self, $tnode, $anode ) = @_;
-    my $lemma  = $anode->lemma           // '';
-    my $number = $anode->morphcat_number // 'S';
-    my $countability = Treex::Tool::Lexicon::EN::Countability::countability($lemma);
-    my $article      = '';
-    my $rule         = '?';
 
-    $self->replace_some_with_indef( $tnode, $countability );
-    
-    #
-    # fixed rules
-    #
-
-    if ( _has_determiner($tnode) ) {
-        $article = '';
-        $rule    = 'has_determiner';
-    }
-    elsif ( _is_noun_premodifier($tnode) ) {
-        $article = '';
-        $rule    = 'is_noun_premodifier';
-    }
-    elsif ( $self->_local_context->{$lemma} ) {
-        $article = 'the';
-        $rule    = 'local_context';
-    }
-    elsif ( $tnode->gram_definiteness ) {
-        $article = $tnode->gram_definiteness eq 'def1' ? 'the' : 'a';
-        $rule = 'gram/definiteness';
-    }
-    elsif ( _has_relative_clause($tnode) || _is_restricted_somehow( $tnode, $countability ) ) {
-        $article = 'the';
-        $rule    = 'has_relative_clause or is restricted';
-    }
-    elsif ( $countability eq 'countable' && $number eq 'S' ) {
-
-        # John was President, Karl became Pope, Hey Doctor, come closer.
-        $article = $lemma eq ucfirst($lemma) ? '' : _is_topic($anode) ? 'the' : 'a';
-        $rule = 'countable and singular';
-    }
-    elsif ( $countability eq 'countable' && $number eq 'P' ) {
-        $article = '';
-        $rule    = 'countable and plural';
-    }
-    elsif ( $countability eq 'uncountable' ) {
-
-        $rule    = 'uncountable';
-        $article = '';
-
-        # 'a' when modified by an adjective
-        if ( grep { ( $_->gram_sempos // '' ) =~ /^adj/ } $tnode->get_descendants() ) {
-            $article = 'a';
-            $rule    = 'uncountable/with adj';
-        }
-        elsif ( $lemma =~ /^(pity|waste)$/ ) {
-            $article = 'a';
-            $rule    = 'uncountable/pity+waste';
-        }
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_meal($lemma) ) {
-        $article = '';
-        $rule    = 'meal';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_water_body($lemma) ) {
-        $article = 'the';
-        $rule    = 'ocean';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_island($lemma) ) {
-        $article = $lemma =~ /\b(of)\b/ || $number eq 'P' ? 'the' : '';
-        $rule = 'island';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_mountain_peak($lemma) || $lemma =~ /mountain of /i ) {
-        $article = $lemma =~ /\b(of)\b/ ? 'the' : '';
-        $rule = 'mountain';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_mountain_chain($lemma) ) {
-        $article = 'the';
-        $rule    = 'chain of mountains';
-    }
-    elsif ( $lemma =~ /^(Netherlands|Argentine)$/i ) {
-        $article = 'the';
-        $rule    = 'countries exceptions';
-    }
-    elsif ( $lemma =~ /\b(kingdom|union|state|republic|US|UK|U\.S\.)/i ) {
-        $article = 'the';
-        $rule    = 'kingdoms etc';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_country($lemma) ) {
-
-        # other countries than above
-        $article = '';
-        $rule    = 'states';
-    }
-    elsif ( $lemma =~ /\b(union|EU)\b/i ) {
-        $article = 'the';
-        $rule    = 'eu';
-    }
-    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_nation($lemma) ) {
-
-        # The French are strong, The Scottish are bald
-        # BEWARE, this wont work, cos wn3.0 gives the 'people of a nation' into one synset with 'nation, land, country'
-        # thus it will trigger the state test above
-        $article = 'the';
-        $rule    = 'nation';
-    }
-    elsif ( $lemma =~ /^(dozen|thousand)$/i ) {
-        $article = '';
-
-        # a thousand == one thousand
-        $article = 'a' if $number eq 'S';
-        $rule = 'dozen';
-    }
-    elsif ( $lemma =~ /^(lot|deal)$/i ) {
-        $article = 'a';
-        $rule    = 'lot';
-    }
-    elsif ( $lemma =~ /^(left|right|center)$/i ) {
-        $article = 'the';
-        $rule    = 'direction';
-    }
-
-    #
-    # probability rules below this point:
-    #
-    elsif ( $anode->get_attr('is_name') or $lemma eq ucfirst($lemma) ) {
-
-        # Other names that above we want without the article
-        $article = '';
-        $rule    = 'is_name';
-    }
-    elsif ( _is_topic($anode) ) {
-        $article = 'the';
-        $rule    = 'is_topic';
-    }
-    else {
-
-        # = 'the'; # 6mio in bnc, 2mio for 'a'
-        $article = '';
-        $rule    = 'default';
-    }
-    
-    #
-    # create the node and add it to context, if possible
-    #
-    if ($article) {
-        my $article_anode = add_article_node( $anode, $article );
-        $tnode->add_aux_anodes($article_anode);
-    }
-    $anode->wild->{article_rule} = $rule;  # store the rule for debugging purposes
-
-    # rough simulation of 7 salient items in consciousness, should be synsetid and not lemma
-    if ( $article eq 'a' or ( $rule =~ /(determiner|relative)/ and $countability eq 'countable' ) ){
-        $self->_add_to_local_context($lemma);
-    }
-}
-
-sub _has_determiner {
-    my ($tnode) = @_;
-    my @d = grep {
-        $_->t_lemma =~ /^(some|this|those|that|these|which|what|whose|one|no|any|no_one|nobody|nothing|none)$/
-            or ( $_->gram_sempos // '' ) =~ /^(adj.pron.def.pers|n.pron.indef|adj.pron.def.demon)$/
-            or $_->formeme eq 'n:poss'
-    } $tnode->get_echildren();
-    return scalar @d;
-}
-
-sub _is_noun_premodifier {
-    my ($tnode) = @_;
-    my $parent = $tnode->get_parent;
-    return $tnode->formeme =~ /n:attr/ and $parent->gram_sempos =~ /^n/ and $tnode->precedes($parent);
-}
-
-sub _is_topic {
-    my ($anode) = @_;
-
-    # TODO this won't probably work very well (we don't have deepord / TFA here)
-    my $verb = $anode->get_clause_head();
-    return $anode->precedes($verb);
-}
-
-sub _has_relative_clause {
-    my ($tnode) = @_;
-    my @relatives = ();
-    my @relative_clause_heads = grep { $_->formeme eq 'v:rc' } $tnode->get_echildren();
-    if (@relative_clause_heads) {
-        @relatives = grep { $_->t_lemma eq 'which' } $relative_clause_heads[0]->get_echildren();
-    }
-    return scalar @relatives;
-}
-
-sub _is_restricted_somehow {
-    my ($tnode) = @_;
-    
-    # unique identification: "the same/left/right/bottom..."
-    return 1 if ( grep { $_->t_lemma =~ /^(same|left|right|top|bottom|first|second|third|last)$/ } $tnode->get_echildren() );
-    
-    # superlatives: "the best, the greatest..."
-    return 1 if ( grep { ( $_->gram_sempos // '' ) =~ /^adj.denot/ and ( $_->gram_degcmp // '' ) eq 'sup' } $tnode->get_echildren() );
-
-    # TODO this won't probably work
-    return scalar( grep { ( $_->functor // '' ) eq 'LOC' } $tnode->get_children() );
-}
-
-sub add_article_node {
-    my ( $anode, $lemma ) = @_;
-
-    my $article = $anode->create_child(
-        {
-            'lemma'        => $lemma,
-            'form'         => $lemma,
-            'afun'         => 'AuxA',
-            'morphcat/pos' => 'T',
-            'conll/pos'    => 'DT',
-        }
-    );
-    $article->shift_before_subtree($anode);
-    return $article;
-}
-
-sub _add_to_local_context {
-    my ( $self, $lemma ) = @_;
-
-    $self->_local_context->{$lemma} = $self->context_size;
-
-    foreach my $context_lemma ( keys %{ $self->_local_context } ) {
-        $self->_local_context->{$context_lemma}--;
-        delete $self->_local_context->{$context_lemma} if ( !$self->_local_context->{$context_lemma} );
-    }
-    return;
-}
+    # no articles possible/needed for indefinite pronouns
+    return 0 if ( $anode->is_pronoun and ( $tnode->gram_definiteness // '' ) eq 'indefinite' );
+    return 1;
+};
 
 1;
 
@@ -314,18 +41,13 @@ Treex::Block::T2A::EN::AddArticles
 
 =head1 DESCRIPTION
 
-Add a-nodes corresponding to articles of nouns.
-
-Using several heuristic rules to determine the article. Rules will be overridden
-by the values of the definiteness grammateme if C<grammateme_only> is set to C<1>.
+Add a-nodes corresponding to English noun articles, according to the 'definiteness' grammateme.
 
 =head1 AUTHORS 
-
-Jan Ptáček
 
 Ondřej Dušek <odusek@ufal.mff.cuni.cz>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright © 2008-2014 by Institute of Formal and Applied Linguistics, Charles University in Prague
+Copyright © 2015 by Institute of Formal and Applied Linguistics, Charles University in Prague
 This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Block/T2T/CS2EN/AddDefiniteness.pm
+++ b/lib/Treex/Block/T2T/CS2EN/AddDefiniteness.pm
@@ -1,0 +1,298 @@
+package Treex::Block::T2T::CS2EN::AddDefiniteness;
+use utf8;
+use Moose;
+use Moose::Util::TypeConstraints;
+use Treex::Core::Common;
+use Treex::Tool::Lexicon::EN::Countability;
+use Treex::Tool::Lexicon::EN::Hypernyms;
+
+extends 'Treex::Core::Block';
+
+has 'context_size' => ( isa => 'Int', is => 'ro', default => 7 );
+
+enum DiscourseBreaks => [qw/ document sentence /];
+has 'clear_context_after' => ( isa => 'DiscourseBreaks', is => 'ro', default => 'document' );
+
+has '_local_context' => ( isa => 'HashRef', is => 'rw', default => sub { {} } );
+
+after 'process_document' => sub {
+    my ($self) = @_;
+    if ($self->clear_context_after eq 'document') {
+        $self->_set_local_context( {} );    # clear local context after document
+    }
+};
+
+after 'process_bundle' => sub {
+    my ($self) = @_;
+    if ($self->clear_context_after eq 'sentence') {
+        $self->_set_local_context( {} );    # clear local context after each sentence
+    }
+};
+
+sub process_tnode {
+
+    my ( $self, $tnode ) = @_;
+
+    # rule out personal pronouns and generated nodes
+    return if ( $tnode->t_lemma =~ /^#/ );    # or ($tnode->functor // '') eq 'RSTR'
+    
+    # rule out non-nouns
+    return if ( ( $tnode->gram_sempos // '' ) !~ /^n/ and ( $tnode->t_lemma // '' ) !~ /^(dozen|thousand|lot|deal)$/ );
+
+    $self->decide_article( $tnode );
+    return;
+}
+
+sub replace_some_with_indef {
+    my ($self, $tnode, $countability) = @_;
+
+    return 0 if ($countability && $countability ne 'countable');
+    return 0 if (!defined $tnode->gram_number || $tnode->gram_number ne 'sg');
+    my ($some_tnode) = grep {$_->t_lemma eq 'some'} $tnode->get_children;
+    return 0 if (!defined $some_tnode);
+
+    $some_tnode->remove({children=>'rehang'});
+    $tnode->set_gram_definiteness('indefinite');
+    return 1;
+}
+
+sub decide_article {
+    my ( $self, $tnode ) = @_;
+    my $lemma  = $tnode->t_lemma // '';
+    my $number = $tnode->gram_number // 'sg';
+    my $countability = Treex::Tool::Lexicon::EN::Countability::countability($lemma);
+    my $article      = '';
+    my $rule         = '?';
+
+    #
+    # fixed rules
+    #
+
+    if ( $self->replace_some_with_indef( $tnode, $countability ) ){
+        $article = 'a';
+        $rule = 'replace_some_with_indef';
+    }
+    elsif ( _has_determiner($tnode) ) {
+        $article = '';
+        $rule    = 'has_determiner';
+    }
+    elsif ( _is_noun_premodifier($tnode) ) {
+        $article = '';
+        $rule    = 'is_noun_premodifier';
+    }
+    elsif ( $self->_local_context->{$lemma} ) {
+        $article = 'the';
+        $rule    = 'local_context';
+    }
+    elsif ( _has_relative_clause($tnode) || _is_restricted_somehow( $tnode, $countability ) ) {
+        $article = 'the';
+        $rule    = 'has_relative_clause or is restricted';
+    }
+    elsif ( $countability eq 'countable' && $number eq 'sg' ) {
+
+        # John was President, Karl became Pope, Hey Doctor, come closer.
+        $article = $lemma eq ucfirst($lemma) ? '' : _is_topic($tnode) ? 'the' : 'a';
+        $rule = 'countable and singular';
+    }
+    elsif ( $countability eq 'countable' && $number eq 'pl' ) {
+        $article = '';
+        $rule    = 'countable and plural';
+    }
+    elsif ( $countability eq 'uncountable' ) {
+
+        $rule    = 'uncountable';
+        $article = '';
+
+        # 'a' when modified by an adjective
+        if ( grep { ( $_->gram_sempos // '' ) =~ /^adj/ } $tnode->get_descendants() ) {
+            $article = 'a';
+            $rule    = 'uncountable/with adj';
+        }
+        elsif ( $lemma =~ /^(pity|waste)$/ ) {
+            $article = 'a';
+            $rule    = 'uncountable/pity+waste';
+        }
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_meal($lemma) ) {
+        $article = '';
+        $rule    = 'meal';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_water_body($lemma) ) {
+        $article = 'the';
+        $rule    = 'ocean';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_island($lemma) ) {
+        $article = $lemma =~ /\b(of)\b/ || $number eq 'pl' ? 'the' : '';
+        $rule = 'island';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_mountain_peak($lemma) || $lemma =~ /mountain of /i ) {
+        $article = $lemma =~ /\b(of)\b/ ? 'the' : '';
+        $rule = 'mountain';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_mountain_chain($lemma) ) {
+        $article = 'the';
+        $rule    = 'chain of mountains';
+    }
+    elsif ( $lemma =~ /^(Netherlands|Argentine)$/i ) {
+        $article = 'the';
+        $rule    = 'countries exceptions';
+    }
+    elsif ( $lemma =~ /\b(kingdom|union|state|republic|US|UK|U\.S\.)/i ) {
+        $article = 'the';
+        $rule    = 'kingdoms etc';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_country($lemma) ) {
+
+        # other countries than above
+        $article = '';
+        $rule    = 'states';
+    }
+    elsif ( $lemma =~ /\b(union|EU)\b/i ) {
+        $article = 'the';
+        $rule    = 'eu';
+    }
+    elsif ( Treex::Tool::Lexicon::EN::Hypernyms::is_nation($lemma) ) {
+
+        # The French are strong, The Scottish are bald
+        # BEWARE, this wont work, cos wn3.0 gives the 'people of a nation' into one synset with 'nation, land, country'
+        # thus it will trigger the state test above
+        $article = 'the';
+        $rule    = 'nation';
+    }
+    elsif ( $lemma =~ /^(dozen|thousand)$/i ) {
+        $article = '';
+
+        # a thousand == one thousand
+        $article = 'a' if $number eq 'sg';
+        $rule = 'dozen';
+    }
+    elsif ( $lemma =~ /^(lot|deal)$/i ) {
+        $article = 'a';
+        $rule    = 'lot';
+    }
+    elsif ( $lemma =~ /^(left|right|center)$/i ) {
+        $article = 'the';
+        $rule    = 'direction';
+    }
+
+    #
+    # probability rules below this point:
+    #
+    elsif ( $tnode->is_name_of_person or $lemma eq ucfirst($lemma) ) {
+
+        # Other names that above we want without the article
+        $article = '';
+        $rule    = 'is_name';
+    }
+    elsif ( _is_topic($tnode) ) {
+        $article = 'the';
+        $rule    = 'is_topic';
+    }
+    else {
+        # = 'the'; # 6mio in bnc, 2mio for 'a'
+        $article = '';
+        $rule    = 'default';
+    }
+    
+    #
+    # create the node and add it to context, if possible
+    #
+    if ($article) {
+        $tnode->set_gram_definiteness($article eq 'the' ? 'definite' : 'indefinite');
+    }
+    log_info($tnode->t_lemma . ' ' . $rule . ' ' . $article);
+    $tnode->wild->{article_rule} = $rule;  # store the rule for debugging purposes
+
+    # rough simulation of 7 salient items in consciousness, should be synsetid and not lemma
+    if ( $article eq 'a' or ( $rule =~ /(determiner|relative)/ and $countability eq 'countable' ) ){
+        $self->_add_to_local_context($lemma);
+    }
+}
+
+sub _has_determiner {
+    my ($tnode) = @_;
+    my @d = grep {
+        $_->t_lemma =~ /^(some|this|those|that|these|which|what|whose|one|no|any|no_one|nobody|nothing|none)$/
+            or ( $_->gram_sempos // '' ) =~ /^(adj.pron.def.pers|n.pron.indef|adj.pron.def.demon)$/
+            or $_->formeme eq 'n:poss'
+    } $tnode->get_echildren();
+    return scalar @d;
+}
+
+sub _is_noun_premodifier {
+    my ($tnode) = @_;
+    my $parent = $tnode->get_parent;
+    return $tnode->formeme =~ /n:attr/ and $parent->gram_sempos =~ /^n/ and $tnode->precedes($parent);
+}
+
+sub _is_topic {
+    my ($tnode) = @_;
+
+    # TODO this won't probably work very well (we don't have deepord / TFA here)
+    my $verb = $tnode->get_clause_head();
+    return $tnode->precedes($verb);
+}
+
+sub _has_relative_clause {
+    my ($tnode) = @_;
+    my @relatives = ();
+    my @relative_clause_heads = grep { $_->formeme eq 'v:rc' } $tnode->get_echildren();
+    if (@relative_clause_heads) {
+        @relatives = grep { $_->t_lemma eq 'which' } $relative_clause_heads[0]->get_echildren();
+    }
+    return scalar @relatives;
+}
+
+sub _is_restricted_somehow {
+    my ($tnode) = @_;
+    
+    # unique identification: "the same/left/right/bottom..."
+    return 1 if ( grep { $_->t_lemma =~ /^(same|left|right|top|bottom|first|second|third|last)$/ } $tnode->get_echildren() );
+    
+    # superlatives: "the best, the greatest..."
+    return 1 if ( grep { ( $_->gram_sempos // '' ) =~ /^adj.denot/ and ( $_->gram_degcmp // '' ) eq 'sup' } $tnode->get_echildren() );
+
+    # TODO this won't probably work
+    return scalar( grep { ( $_->functor // '' ) eq 'LOC' } $tnode->get_children() );
+}
+
+
+sub _add_to_local_context {
+    my ( $self, $lemma ) = @_;
+
+    $self->_local_context->{$lemma} = $self->context_size;
+
+    foreach my $context_lemma ( keys %{ $self->_local_context } ) {
+        $self->_local_context->{$context_lemma}--;
+        delete $self->_local_context->{$context_lemma} if ( !$self->_local_context->{$context_lemma} );
+    }
+    return;
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME 
+
+Treex::Block::T2A::EN::AddArticles
+
+=head1 DESCRIPTION
+
+Add a-nodes corresponding to articles of nouns.
+
+Using several heuristic rules to determine the article. Rules will be overridden
+by the values of the definiteness grammateme if C<grammateme_only> is set to C<1>.
+
+=head1 AUTHORS 
+
+Jan Ptáček
+
+Ondřej Dušek <odusek@ufal.mff.cuni.cz>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright © 2008-2014 by Institute of Formal and Applied Linguistics, Charles University in Prague
+This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Block/W2A/CS/FixGuessedLemmas.pm
+++ b/lib/Treex/Block/W2A/CS/FixGuessedLemmas.pm
@@ -199,7 +199,7 @@ sub fix_lemma_capitalization {
         my $l_letter = substr $lemma, $i, 1;
         my $f_letter = substr $form,  $i, 1;
 
-        last if ( lc $l_letter != lc $f_letter );
+        last if ( lc $l_letter ne lc $f_letter );
         $new_lemma .= $f_letter;
     }
     $new_lemma .= substr $lemma, $i;

--- a/lib/Treex/Block/W2A/CS/FixGuessedLemmas.pm
+++ b/lib/Treex/Block/W2A/CS/FixGuessedLemmas.pm
@@ -5,17 +5,18 @@ use Treex::Core::Common;
 
 use PerlIO::gzip;
 use Tree::Trie;
+
 #use Text::Levenshtein qw/distance/;
 use Text::Brew;
 use List::Util qw/min/;
 
 extends 'Treex::Core::Block';
 
-has 'forms_list_path' => ( is => 'ro', isa => 'Str', default => 'data/models/ne_lemma_fix/cswiki.forms.freq.txt.gz');
-has '_forms_list' => ( is => 'ro', isa => 'HashRef[Str]', builder => '_build_forms_list', lazy => 1);
+has 'forms_list_path' => ( is => 'ro', isa => 'Str', default => 'data/models/ne_lemma_fix/cswiki.forms.freq.txt.gz' );
+has '_forms_list' => ( is => 'ro', isa => 'HashRef[Str]', builder => '_build_forms_list', lazy => 1 );
 
-has 'lemmas_list_path' => ( is => 'ro', isa => 'Str', default => 'data/models/ne_lemma_fix/cswiki.lemmas.list.txt.gz');
-has '_lemmas_list' => ( is => 'ro', isa => 'Tree::Trie', builder => '_build_lemmas_list', lazy => 1);
+has 'lemmas_list_path' => ( is => 'ro', isa => 'Str', default => 'data/models/ne_lemma_fix/cswiki.lemmas.list.txt.gz' );
+has '_lemmas_list' => ( is => 'ro', isa => 'Tree::Trie', builder => '_build_lemmas_list', lazy => 1 );
 
 #has 'suffix_change_threshold' => ( is => 'ro', isa => 'Num', default => 0.3 );
 
@@ -30,30 +31,30 @@ sub _build_forms_list {
 
     my $forms_freq = {};
 
-    my $path = require_file_from_share($self->forms_list_path);
+    my $path = require_file_from_share( $self->forms_list_path );
     log_info "Loading a list of forms not contained in the MorphoDiTa dictionary from '$path'";
     open my $forms_fh, "<:gzip:utf8", $path or die $!;
     while (<$forms_fh>) {
         chomp $_;
         $_ =~ s/^\s*//;
         $_ =~ s/\s*$//;
-        my ($count, $form) = split /\s+/, $_;
-        my $cap_hash = $forms_freq->{lc($form)};
-        if (defined $cap_hash) {
+        my ( $count, $form ) = split /\s+/, $_;
+        my $cap_hash = $forms_freq->{ lc($form) };
+        if ( defined $cap_hash ) {
             $cap_hash->{$form} = $count;
         }
         else {
-            $cap_hash = {};
-            $cap_hash->{$form} = $count;
-            $forms_freq->{lc($form)} = $cap_hash; 
+            $cap_hash                  = {};
+            $cap_hash->{$form}         = $count;
+            $forms_freq->{ lc($form) } = $cap_hash;
         }
     }
     close $forms_fh;
 
     my $forms_list = {};
-    foreach my $key (keys %$forms_freq) {
+    foreach my $key ( keys %$forms_freq ) {
         my $cap_hash = $forms_freq->{$key};
-        my ($max_key) = sort {$cap_hash->{$b} <=> $cap_hash->{$a}} keys %$cap_hash;
+        my ($max_key) = sort { $cap_hash->{$b} <=> $cap_hash->{$a} } keys %$cap_hash;
         $forms_list->{$key} = $max_key;
     }
 
@@ -65,36 +66,36 @@ sub _build_lemmas_list {
 
     my $ll_trie = Tree::Trie->new();
 
-    my $path = require_file_from_share($self->lemmas_list_path);
+    my $path = require_file_from_share( $self->lemmas_list_path );
     log_info "Loading a list of lemmas not contained in the MorphoDiTa dictionary from '$path'";
     open my $ll_fh, "<:gzip:utf8", $path;
     while (<$ll_fh>) {
         chomp $_;
-        $ll_trie->add(lc($_));
+        $ll_trie->add( lc($_) );
     }
     close $ll_fh;
     return $ll_trie;
 }
 
 sub is_change_minor {
-    my ($self, $old_word, $new_word, $dist) = @_;
+    my ( $self, $old_word, $new_word, $dist ) = @_;
 
     #return ($dist / length($old_word)) < $self->suffix_change_threshold;
-    return ($dist < 3);
+    return ( $dist < 3 );
 }
 
 sub distance {
-    my ($str1, $str2) = @_;
+    my ( $str1, $str2 ) = @_;
 
-    my ($dist, $edits) = Text::Brew::distance($str1, $str2);
-    
+    my ( $dist, $edits ) = Text::Brew::distance( $str1, $str2 );
+
     my $match_penalty = 1;
     my $weighted_dist = 0;
-    foreach my $edit (reverse @$edits) {
-        if ($edit eq 'INITIAL') {
+    foreach my $edit ( reverse @$edits ) {
+        if ( $edit eq 'INITIAL' ) {
             next;
         }
-        elsif ($edit ne 'MATCH') {
+        elsif ( $edit ne 'MATCH' ) {
             $weighted_dist += $match_penalty;
         }
         else {
@@ -112,41 +113,100 @@ sub process_anode {
     #return if (lc($anode->form) eq $anode->form);
 
     # fix only those guessed by a lemmatizer
-    return if (!$anode->wild->{lemma_guessed});
-#    log_info "LEMMA GUESSED: ".$anode->lemma;
+    return if ( !$anode->wild->{lemma_guessed} );
 
-    # fix only those nodes, whose guessed lemma cannot be found in the list
-    return if ($self->_forms_list->{lc($anode->lemma)});
-#    log_info "LEMMA NOT FOUND: ".$anode->lemma;
-    
-    my $lc_form = lc($anode->form);
-#    log_info "LC_FORM: $lc_form";
+    #    log_info "LEMMA GUESSED: ".$anode->lemma;
+
+    # fix only nodes whose guessed lemma cannot be found in the list
+    if ( not $self->_forms_list->{ lc( $anode->lemma ) } ) {
+        return if $self->fix_lemma_using_list($anode);
+    }
+
+    # try rules for fixing lemmas
+    return if $self->fix_lemma_using_rules($anode);
+
+    # for lemmas not fixed, try to keep the lemma capitalization as it is in the word
+    if ( $anode->form =~ /\p{Lu}/ and $anode->form =~ /\p{Ll}/ and $anode->lemma !~ /\p{Lu}/ and $anode->ord > 1 ) {
+        $self->fix_lemma_capitalization($anode);
+    }
+}
+
+# Trying to fix a lemma using a list from Wikipedia, return status (1: fixed, 0: left untouched)
+sub fix_lemma_using_list {
+
+    my ( $self, $anode ) = @_;
+
+    #    log_info "LEMMA NOT FOUND: ".$anode->lemma;
+
+    my $lc_form = lc( $anode->form );
+
+    #    log_info "LC_FORM: $lc_form";
 
     # fix only those whose form can be found in the list
-    return if (!$self->_forms_list->{$lc_form});
+    return 0 if ( !$self->_forms_list->{$lc_form} );
 
     my $wt = $self->_lemmas_list;
     $wt->deepsearch('prefix');
     my $longest_prefix = $wt->lookup($lc_form);
-    return if (!$longest_prefix);
-#    log_info "LONGEST_PREFIX: $longest_prefix";
-    
+    return 0 if ( !$longest_prefix );
+
+    #    log_info "LONGEST_PREFIX: $longest_prefix";
+
     my @possible_words = $wt->lookup($longest_prefix);
-    my @distances = map {distance($lc_form, $_)} @possible_words;
+    my @distances = map { distance( $lc_form, $_ ) } @possible_words;
 
     my $min_dist = min @distances;
-#    log_info "MIN_DIST: $min_dist";
-    my ($new_lc_lemma) = @possible_words[(grep {$distances[$_] == $min_dist} 0 .. $#distances)];
-#    log_info "NEW LC LEMMA: $new_lc_lemma";
 
-    return if (!$self->is_change_minor($lc_form, $new_lc_lemma, $min_dist));
+    #    log_info "MIN_DIST: $min_dist";
+    my ($new_lc_lemma) = @possible_words[ ( grep { $distances[$_] == $min_dist } 0 .. $#distances ) ];
+
+    #    log_info "NEW LC LEMMA: $new_lc_lemma";
+
+    return 0 if ( !$self->is_change_minor( $lc_form, $new_lc_lemma, $min_dist ) );
 
     #if (defined $new_lemma) {
     my $new_lemma = $self->_forms_list->{$new_lc_lemma};
-    return if (!defined $new_lemma);
-#    log_info "NEW LEMMA: $new_lemma";
+    return 0 if ( !defined $new_lemma );
+
+    #    log_info "NEW LEMMA: $new_lemma";
     $anode->set_lemma($new_lemma);
+    $anode->wild->{ne_lemma_fix} = 1;
+
     #}
+    return 1;
+}
+
+sub fix_lemma_using_rules {
+    my ( $self, $anode ) = @_;
+
+    my $form = $anode->form;
+    if ( $form =~ /^iPad(u|em|y|ů|ech)$/ ) {
+        $anode->set_lemma('iPad');
+        return 1;
+    }
+    return 0;
+}
+
+sub fix_lemma_capitalization {
+    my ( $self, $anode ) = @_;
+
+    my $lemma     = $anode->lemma;
+    my $form      = $anode->form;
+    my $new_lemma = '';
+    my $i         = 0;
+
+    for ( ; $i < min( length($lemma), length($form) ); ++$i ) {
+        my $l_letter = substr $lemma, $i, 1;
+        my $f_letter = substr $form,  $i, 1;
+
+        last if ( lc $l_letter != lc $f_letter );
+        $new_lemma .= $f_letter;
+    }
+    $new_lemma .= substr $lemma, $i;
+    $anode->set_lemma($new_lemma);
+    $anode->wild->{lemma_cap_fix} = 1;
+
+    return;
 }
 
 1;

--- a/lib/Treex/Scen/Analysis/CS.pm
+++ b/lib/Treex/Scen/Analysis/CS.pm
@@ -60,6 +60,7 @@ sub get_scenario_string {
     # n-layer
     $self->ner eq 'NameTag' ? 'A2N::CS::NameTag' : (),
     $self->ner eq 'simple' ? 'A2N::CS::SimpleRuleNER' : (),
+    $self->domain eq 'IT' ? 'A2N::CS::FixNERforIT' : (),
     'A2N::CS::NormalizeNames',
 
     # a-layer

--- a/lib/Treex/Scen/Synthesis/EN.pm
+++ b/lib/Treex/Scen/Synthesis/EN.pm
@@ -23,7 +23,7 @@ sub get_scenario_string {
     'T2A::EN::AddInfinitiveParticles',
     'T2A::EN::AddPhrasalVerbParticles',
     'T2A::EN::AddPossessiveMarkers',
-    'T2A::EN::AddArticles' . ($self->domain eq 'IT' ? ' clear_context_after=sentence' : ''), # TODO: this has nothing to do with IT domain
+    'T2A::EN::AddArticles',
     'T2A::EN::AddAuxVerbCompoundPassive',
     'T2A::EN::AddAuxVerbModalTense',
     'T2A::EN::AddAuxVerbInter',

--- a/lib/Treex/Scen/Transfer/CS2EN.pm
+++ b/lib/Treex/Scen/Transfer/CS2EN.pm
@@ -103,6 +103,7 @@ sub get_scenario_string {
     $self->domain eq 'IT' ? 'T2T::CS2EN::DeleteSuperfluousNodes' : (), # deletes word "application" and "system" with NE, this rarely influences non-IT domain
     'T2T::CS2EN::FixGrammatemesAfterTransfer',
     'T2T::CS2EN::FixDoubleNegative',
+    'T2T::CS2EN::AddDefiniteness' . ( $self->domain eq 'IT' ? ' clear_context_after=sentence' : '' ),    # TODO: this has nothing to do with IT domain
     ;
     return $scen;
 }


### PR DESCRIPTION
The block `T2A::EN::AddArticles` now just assigns articles according to the definiteness grammateme and does not try to guess them (which was a legacy function, designed for CS-EN translation only).

The article guessing rules have been moved to CS-EN transfer (`T2T::CS2EN::AddDefiniteness`).

In addition, several fixes in Czech and language-independent analysis were needed to keep the performance approximately similar. 

All X-to-EN language pairs (except CS-EN) should receive gains from this, since they have articles and it is safer to copy the definiteness grammateme from the source language than to try and guess.