### PR TITLE
Fix for parsing "and then click..."

### DIFF
--- a/lib/Treex/Block/W2A/EN/FixAtree.pm
+++ b/lib/Treex/Block/W2A/EN/FixAtree.pm
@@ -321,6 +321,12 @@ sub fix_node {
             $node->set_parent($five);
         }
     }
+    
+    # and then do... -- rehang "then" from "and" to "do"
+    if ( $lemma eq 'then' && !@children && $p_lemma eq 'and' and $next_node and $next_node->tag =~ /^VB/ ){
+        $node->set_parent($next_node);
+        $node->set_is_member(undef);
+    }
 
     return;
 }


### PR DESCRIPTION
"Then" should go under the following verb, but ends up under "and".
This rehangs it. The change does not yield a BLEU improvement for EN-CS
translation on Batch2a, but it reads a bit more smoothly (without
extra commas after "potom").