### PR TITLE
A tiny fix to allow local parallel execution

### DIFF
--- a/lib/Treex/Core/Parallel/Head.pm
+++ b/lib/Treex/Core/Parallel/Head.pm
@@ -306,7 +306,12 @@ sub _run_job_script {
     my $script_filename = "scripts/job" . sprintf( "%03d", $jobnumber ) . ".sh";
 
     if ( $self->local ) {
-        system "$workdir/$script_filename &";
+        my $pid = fork();
+        if (!$pid){
+            # I am the child process: replace me with the job script (will never return)
+            exec "$workdir/$script_filename";
+        }
+        push @{ $self->sge_job_numbers }, $pid;
     }
     else {
         my $mem       = $self->mem;
@@ -1072,6 +1077,13 @@ sub _delete_jobs {
     my $self = shift;
 
     log_info "Deleting jobs: " . join( ', ', @{ $self->sge_job_numbers } );
+
+    if ($self->local){
+        # The only thing we need to do here is exit the program – child processes
+        # will die automatically.
+        return;
+    }
+
     my %jobs = ();
     foreach my $job ( @{ $self->sge_job_numbers } ) {
         qx(qdel $job);


### PR DESCRIPTION
Parallel execution on a single local machine has been here all along, since the time Martin Majlis implemented it (the parameter `--local` is even documented in `Treex::Core::Run`)... I only never knew.

The only problem was that killing the Head process did not kill all the processing Nodes. This tiny change fixes the problem, so we may now run Treex in parallel on a single machine (using e.g. `treex -p -j 4 --local`).

Note that no memory checking is done, so the user must make sure that the whole thing will fit into memory (e.g. parsers/translation models need to load *n* times).