### PR TITLE
Fixing DocumentReader to work with skip_finished in parallel

### DIFF
--- a/lib/Treex/Core/DocumentReader.pm
+++ b/lib/Treex/Core/DocumentReader.pm
@@ -65,7 +65,19 @@ sub next_document_for_this_job {
         if ($res) {
             $self->_set_file_number(0);
             $self->_set_doc_number( $res->{file_number} - 1 );
-            $self->from->_set_filenames( [ $res->{result} ] );    # $res->{result} contains the next file name
+            
+            # $res->{result} contains the next file name for plain readers,
+            # a hashref: zone -> file name for aligned readers
+            if (ref($res->{result}) eq 'HASH'){
+                # here we assume that all zones exist in _filenames 
+                # (they should since all arguments are passed on to jobs)
+                while (my ($zone, $filename) = each %{$res->{result}}){
+                    $self->_filenames->{$zone}->_set_filenames( [ $filename ] );
+                }
+            }
+            else {
+                $self->from->_set_filenames( [ $res->{result} ] );
+            }
         }
 
         # Martin Majliš had the following for BaseAlignedReader but I see no reason for it.

--- a/lib/Treex/Core/DocumentReader.pm
+++ b/lib/Treex/Core/DocumentReader.pm
@@ -65,7 +65,7 @@ sub next_document_for_this_job {
         if ($res) {
             $self->_set_file_number(0);
             $self->_set_doc_number( $res->{file_number} - 1 );
-            $self->from->_set_filenames( [ $res->{result} ] );
+            $self->from->_set_filenames( [ $res->{result} ] );    # $res->{result} contains the next file name
         }
 
         # Martin Majliš had the following for BaseAlignedReader but I see no reason for it.

--- a/lib/Treex/Core/DocumentReader.pm
+++ b/lib/Treex/Core/DocumentReader.pm
@@ -41,25 +41,33 @@ has doc_number => (
 
 has consumer => (
     isa => 'Treex::Block::Read::ConsumerReader',
-    is => 'rw'
+    is  => 'rw'
 );
 
 sub next_document_for_this_job {
     my ($self) = @_;
 
-    # TODO this is very ugly hack (next_filename _set_file_number is defined only in BaseReader and BaseAlignedReader)
-    # In parallel execution, the file_number is sent from the head to the workers via TCP
-    # and only one doc per file is allowed, so we can update $self->file_number and $self->doc_number
-    # before each call of next_document.
-    # However the implementation of next_document will increase the numbers, so we must set it -1.
-    # This code must be specified here in next_document_for_this_job because method next_filename may be overriden
-    # or it may not be used at all (e.g. BaseTextReader delegas its functionality to Treex::Core::Files).
+    # In parallel execution, the file name is sent from the head to the workers via TCP
+    # and only one doc per file is allowed, so we can override the file list to contain just
+    # the file to be processed and set the $self->file_number counter to 0 – just before the file
+    # to be processed (we will get another file name and reset it again next time).
+    #
+    # $self->doc_number is set to the number of processed files minus 1 since it will be increased
+    # in next_document().
+    #
+    # This is an ugly hack (next_filename _set_file_number is defined only in BaseReader and BaseAlignedReader),
+    # but this code must be specified here in next_document_for_this_job because the method next_filename
+    # may be overriden or may not be used at all (e.g., BaseTextReader delegates its functionality
+    # to Treex::Core::Files).
+
     if ( $self->consumer ) {
         my $res = $self->consumer->call("next_filename");
         if ($res) {
-            $self->_set_file_number($res->{file_number} - 1);
-            $self->_set_doc_number($res->{file_number} - 1);
+            $self->_set_file_number(0);
+            $self->_set_doc_number( $res->{file_number} - 1 );
+            $self->from->_set_filenames( [ $res->{result} ] );
         }
+
         # Martin Majliš had the following for BaseAlignedReader but I see no reason for it.
         # elsif ($self->_files_per_zone){
         #    $self->_set_file_number($self->_files_per_zone + 2);
@@ -101,7 +109,6 @@ sub restart {
     return;
 }
 
-
 # Readers usually do not need any share files,
 # but all blocks should implement this method
 # and readers do not extend Treex::Core::Block.
@@ -109,7 +116,6 @@ sub get_required_share_files {
     my ($self) = @_;
     return ();
 }
-
 
 1;
 


### PR DESCRIPTION
In parallel processing, using `skip_finished` could lead to unpredictable
results as each of the workers creates its own list of files to
process. The lists will not be identical if some of the workers start
earlier and finish some files before other workers start. This leads
to some files being processed multiple times (with clashes on the output,
making it unreadable), and some files not being processed at all.

This is an attempt to fix this by overriding the file lists in parallel
processing, replacing the list with just the single file to be processed
next each time.

I tested this in a few simple cases (including extracting vectors from 400k files
in 100 jobs) and it seems to work well. If you have a specific tricky scenario to
test it before merging, please let me know.

(Sorry about `Block::Write::YAML` appearing here, I commited it to master as well but it somehow got a different hash)