### PR TITLE
Switching to bidirectional alignment in AttributeParameterized

### DIFF
--- a/lib/Treex/Block/Write/AttributeParameterized.pm
+++ b/lib/Treex/Block/Write/AttributeParameterized.pm
@@ -4,6 +4,7 @@ use Moose::Role;
 use Moose::Util::TypeConstraints;
 use Treex::Core::Log;
 use Readonly;
+use Treex::Tool::Align::Utils;
 
 #
 # DATA
@@ -356,9 +357,9 @@ sub _get_referenced_nodes {
                 }
             }
 
-            # get alignment from $node->get_aligned_nodes()
+            # get alignment going in both directions, using Treex::Tool::Align::Utils 
             else {
-                my ( $aligned_nodes, $aligned_nodes_types ) = $node->get_aligned_nodes();
+                my ( $aligned_nodes, $aligned_nodes_types ) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node);
                 if ($aligned_nodes) {
                     $self->_cache->{$ref}->{$node} = $aligned_nodes;
                 }


### PR DESCRIPTION
This uses the `Treex::Tool::Align::Utils` module by @michnov to provide bidirectional alignment – i.e. all nodes aligned *from and to* the current node will be returned for `aligned->`.

It works for me and I think it's better like this, but perhaps @ptakopysk may have a problem with it? Actually, @ptakopysk, could you use this to get rid of the `$alignment_hash` variable? It would make the code much nicer...