### PR TITLE
Aligned role, support for undirected access and filtering

### DIFF
--- a/lib/Treex/Block/A2A/BackupTree.pm
+++ b/lib/Treex/Block/A2A/BackupTree.pm
@@ -63,7 +63,7 @@ sub process_atree {
     		my @referring_nodes = $sn->get_referencing_nodes('alignment');
     		if (@referring_nodes) {
     			foreach my $rn (@referring_nodes) {
-    				my ($nodes_ref, $types_ref) = $rn->get_aligned_nodes({ 
+    				my ($nodes_ref, $types_ref) = $rn->get_directed_aligned_nodes({ 
                         language => $src_language, 
                         selector => $src_selector
                     });
@@ -78,7 +78,7 @@ sub process_atree {
     	}    	
     	# replicate outgoing alignments (if any) in 'source_selector' to 'to_selector'
     	foreach my $i (0..$#src_nodes) {
-    		my ($nodes_ref, $types_ref) = $src_nodes[$i]->get_aligned_nodes();
+    		my ($nodes_ref, $types_ref) = $src_nodes[$i]->get_directed_aligned_nodes();
     		if ($nodes_ref) {
 				my @aligned_nodes = @{$nodes_ref};
 				my @types = @{$types_ref};

--- a/lib/Treex/Block/A2A/BackupTree.pm
+++ b/lib/Treex/Block/A2A/BackupTree.pm
@@ -63,7 +63,11 @@ sub process_atree {
     		my @referring_nodes = $sn->get_referencing_nodes('alignment');
     		if (@referring_nodes) {
     			foreach my $rn (@referring_nodes) {
-    				my ($nodes_ref, $types_ref) = $rn->get_aligned_nodes_by_tree($src_language, $src_selector);
+    				my ($nodes_ref, $types_ref) = $rn->get_aligned_nodes({ 
+                        directed => 1, 
+                        language => $src_language, 
+                        selector => $src_selector
+                    });
     				if ($nodes_ref) {
 						my @aligning_nodes = @{$nodes_ref};
 						my @types = @{$types_ref};

--- a/lib/Treex/Block/A2A/BackupTree.pm
+++ b/lib/Treex/Block/A2A/BackupTree.pm
@@ -64,7 +64,6 @@ sub process_atree {
     		if (@referring_nodes) {
     			foreach my $rn (@referring_nodes) {
     				my ($nodes_ref, $types_ref) = $rn->get_aligned_nodes({ 
-                        directed => 1, 
                         language => $src_language, 
                         selector => $src_selector
                     });

--- a/lib/Treex/Block/A2A/CS/FixAgreement.pm
+++ b/lib/Treex/Block/A2A/CS/FixAgreement.pm
@@ -76,7 +76,7 @@ sub process_zone {
             $self->source_language, 'a', $self->source_selector
         );
         foreach my $en_node ( $en_root->get_descendants ) {
-            my ( $nodes, $types ) = $en_node->get_aligned_nodes();
+            my ( $nodes, $types ) = $en_node->get_directed_aligned_nodes();
             if ( $nodes->[0] ) {
                 $en_counterpart{ $nodes->[0]->id } = $en_node;
             }
@@ -300,7 +300,7 @@ sub remove_node {
         my $en_parent = $self->en($node)->get_eparents(
             { first_only => 1, or_topological => 1 }
         );
-        my ($nodes) = $en_parent->get_aligned_nodes();
+        my ($nodes) = $en_parent->get_directed_aligned_nodes();
         if ( $nodes->[0] && !$nodes->[0]->is_descendant_of($node) ) {
             $parent = $nodes->[0];
         }

--- a/lib/Treex/Block/A2A/CS/FixBy.pm
+++ b/lib/Treex/Block/A2A/CS/FixBy.pm
@@ -38,7 +38,7 @@ sub fix {
 
         # there shouldn't be any other preposition aligned to 'by'
         # so delete it if there is one
-        my ( $nodes, $types ) = $aligned_parent->get_aligned_nodes();
+        my ( $nodes, $types ) = $aligned_parent->get_directed_aligned_nodes();
         if ( my $node_aligned_to_by = $$nodes[0] ) {
             if ( $node_aligned_to_by->tag =~ /^R/ ) {
                 $self->logfix1( $node_aligned_to_by, "By (aligned prep)" );

--- a/lib/Treex/Block/A2A/CS/FixNounClusters.pm
+++ b/lib/Treex/Block/A2A/CS/FixNounClusters.pm
@@ -31,7 +31,7 @@ sub fix {
         )
     {
 
-        my ($nodes) = $en_gov->get_aligned_nodes();
+        my ($nodes) = $en_gov->get_directed_aligned_nodes();
         if ( !$nodes || !@$nodes ) { return; }
 
         my $cs_gov = $nodes->[0];

--- a/lib/Treex/Block/A2A/CS/FixPrepositionWithoutChildren.pm
+++ b/lib/Treex/Block/A2A/CS/FixPrepositionWithoutChildren.pm
@@ -19,7 +19,7 @@ sub fix {
             return;
         }
         foreach my $en_child ( $self->en($node)->get_children ) {
-            my ( $nodes, $types ) = $en_child->get_aligned_nodes;
+            my ( $nodes, $types ) = $en_child->get_directed_aligned_nodes;
 
             #if (!$nodes) { return; }
             my @cs_children = $$nodes[0];

--- a/lib/Treex/Block/A2A/CopySurfaceFromAlignment.pm
+++ b/lib/Treex/Block/A2A/CopySurfaceFromAlignment.pm
@@ -23,7 +23,7 @@ sub _get_aligned_node {
 
     my ( $anode ) = @_;
 
-    my ($aligned) = $anode->get_aligned_nodes();
+    my ($aligned) = $anode->get_directed_aligned_nodes();
 
     if ($aligned) {
         return $aligned->[0];

--- a/lib/Treex/Block/A2A/FlowNetwork.pm
+++ b/lib/Treex/Block/A2A/FlowNetwork.pm
@@ -69,7 +69,7 @@ sub process_bundle {
             $alignment_total += $BASE_WEIGHT;
         }
         next if $s_ord == 0;
-        my ($alinodes, $alitypes) = $source_nodes[$s_ord - 1]->get_aligned_nodes();
+        my ($alinodes, $alitypes) = $source_nodes[$s_ord - 1]->get_directed_aligned_nodes();
         foreach my $n (0 .. $#$alinodes) {
             my $t_ord = $$alinodes[$n]->ord;
             my $weight = $$alitypes[$n] =~ /left/ ? $BONUS : 0;

--- a/lib/Treex/Block/A2A/MaxCycles.pm
+++ b/lib/Treex/Block/A2A/MaxCycles.pm
@@ -151,7 +151,7 @@ sub process_bundle {
             $alignment_matrix[$s_ord][$t_ord] = 0;
         }
         next if $s_ord == 0;
-        my ($alinodes, $alitypes) = $source_nodes[$s_ord - 1]->get_aligned_nodes();
+        my ($alinodes, $alitypes) = $source_nodes[$s_ord - 1]->get_directed_aligned_nodes();
         foreach my $n (0 .. $#$alinodes) {
             my $t_ord = $$alinodes[$n]->ord;
             my $weight = $$alitypes[$n] =~ /int/ ? $ALIGNMENT_BONUS : 0;

--- a/lib/Treex/Block/A2A/ProjectTreeThroughAlignment.pm
+++ b/lib/Treex/Block/A2A/ProjectTreeThroughAlignment.pm
@@ -26,7 +26,7 @@ sub process_bundle {
 
     # sort counterparts for each node from 'int' through 'gdfa' to 'right'
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( 0, $#$nodes ) {
             if ( $$types[$i] =~ /int/ ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];
@@ -35,7 +35,7 @@ sub process_bundle {
         }
     }
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( 0, $#$nodes ) {
             if ( $$types[$i] =~ /gdfa/ && $$types[$i] !~ /int/ ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];
@@ -44,7 +44,7 @@ sub process_bundle {
         }
     }
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( 0, $#$nodes ) {
             if ( $$types[$i] =~ /right/ && $$types[$i] !~ /gdfa/ ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];

--- a/lib/Treex/Block/A2A/Retokenize.pm
+++ b/lib/Treex/Block/A2A/Retokenize.pm
@@ -31,7 +31,7 @@ sub process_anode {
         # (otherwise simply return)
         
         my $aroot = $anode->get_root();
-        my ($aligned_nodes_rf, $aligned_types_rf) = $anode->get_aligned_nodes();
+        my ($aligned_nodes_rf, $aligned_types_rf) = $anode->get_directed_aligned_nodes();
     
         my $new_node;
         my @unaligned_nodes;

--- a/lib/Treex/Block/A2A/TA/FixAlignments.pm
+++ b/lib/Treex/Block/A2A/TA/FixAlignments.pm
@@ -43,7 +43,7 @@ sub delete_alignment_links {
 		foreach my $i (0..$#src_nodes) {
 			if ($self->alignment_direction eq 'trg2src') {
 				my @referring_nodes = grep {
-                    $_->is_aligned_to($src_nodes[$i], { rel_types => ['^'.$self->alignment_type.'$']})
+                    $_->is_directed_aligned_to($src_nodes[$i], { rel_types => ['^'.$self->alignment_type.'$']})
                 } $src_nodes[$i]->get_referencing_nodes('alignment', $self->language, $self->selector);	
 				if (@referring_nodes) {
 					# delete alignments for some English function words that do not have 

--- a/lib/Treex/Block/A2A/TA/FixAlignments.pm
+++ b/lib/Treex/Block/A2A/TA/FixAlignments.pm
@@ -42,7 +42,9 @@ sub delete_alignment_links {
 		my @src_nodes = $src_root->get_descendants({ordered=>1});
 		foreach my $i (0..$#src_nodes) {
 			if ($self->alignment_direction eq 'trg2src') {
-				my @referring_nodes = grep {$_->is_aligned_to($src_nodes[$i], '^' . $self->alignment_type . '$')} $src_nodes[$i]->get_referencing_nodes('alignment', $self->language, $self->selector);	
+				my @referring_nodes = grep {
+                    $_->is_aligned_to($src_nodes[$i], { rel_types => ['^'.$self->alignment_type.'$']})
+                } $src_nodes[$i]->get_referencing_nodes('alignment', $self->language, $self->selector);	
 				if (@referring_nodes) {
 					# delete alignments for some English function words that do not have 
 					# translation equivalents

--- a/lib/Treex/Block/Align/A/Retokenize.pm
+++ b/lib/Treex/Block/Align/A/Retokenize.pm
@@ -21,7 +21,7 @@ sub process_atree {
 
 			# step 2: split the list of alignment links
 
-			my ( $ali_nodes_rf, $ali_types_rf ) = $node->get_aligned_nodes;
+			my ( $ali_nodes_rf, $ali_types_rf ) = $node->get_directed_aligned_nodes;
 
 			if ($ali_nodes_rf) {
 				foreach my $index ( 0 .. $#$ali_nodes_rf ) {
@@ -47,7 +47,7 @@ sub process_atree {
 			$new_node->shift_before_node($node);
 			$new_node->set_no_space_after(1);
 
-			my ( $ali_nodes_rf, $ali_types_rf ) = $node->get_aligned_nodes;
+			my ( $ali_nodes_rf, $ali_types_rf ) = $node->get_directed_aligned_nodes;
 
 			if ($ali_nodes_rf) {
 				foreach my $index ( 0 .. $#$ali_nodes_rf ) {

--- a/lib/Treex/Block/Align/AlignForward.pm
+++ b/lib/Treex/Block/Align/AlignForward.pm
@@ -23,14 +23,14 @@ sub process_zone {
 
     foreach my $x (@nodes) {
         
-        my ( $ys, $ytypes ) = $x->get_aligned_nodes();
+        my ( $ys, $ytypes ) = $x->get_directed_aligned_nodes();
         next if (!$ys); 
 
         for ( my $i = 0; $i < @{$ys}; ++$i ) {
 
             my ( $y, $ytype ) = ( $ys->[$i], $ytypes->[$i] );
 
-            my ($zs) = $y->get_aligned_nodes();
+            my ($zs) = $y->get_directed_aligned_nodes();
             foreach my $z ( @{$zs} ) {
                 $x->add_aligned_node( $z, $self->preserve_type ? $ytype : $self->align_type );
             }

--- a/lib/Treex/Block/Align/FilterAlignment.pm
+++ b/lib/Treex/Block/Align/FilterAlignment.pm
@@ -19,7 +19,7 @@ sub process_zone {
     my @nodes = $zone->get_tree( $self->layer )->get_descendants( { ordered => 1 } );
 
     foreach my $a (@nodes) {
-        my ($bs, $types) = $a->get_aligned_nodes();
+        my ($bs, $types) = $a->get_directed_aligned_nodes();
         
         next if (!$bs);
         

--- a/lib/Treex/Block/Align/MarkConsistentTreelets.pm
+++ b/lib/Treex/Block/Align/MarkConsistentTreelets.pm
@@ -27,7 +27,7 @@ sub process_node {
         ($node2) = $node1->get_aligned_nodes_of_type('int|rule-based');
         $tree2 ||= $node2->get_root() if $node2;
     } else {
-        ($node2) = grep {$_->is_aligned_to($node1, {rel_types => ['int|rule-based']}) } $node1->get_referencing_nodes('alignment');
+        ($node2) = grep {$_->is_directed_aligned_to($node1, {rel_types => ['int|rule-based']}) } $node1->get_referencing_nodes('alignment');
     }
 
     # If $node1 is aligned, save its alignment as a string to @my_al.

--- a/lib/Treex/Block/Align/MarkConsistentTreelets.pm
+++ b/lib/Treex/Block/Align/MarkConsistentTreelets.pm
@@ -27,7 +27,7 @@ sub process_node {
         ($node2) = $node1->get_aligned_nodes_of_type('int|rule-based');
         $tree2 ||= $node2->get_root() if $node2;
     } else {
-        ($node2) = grep {$_->is_aligned_to($node1, 'int|rule-based')} $node1->get_referencing_nodes('alignment');
+        ($node2) = grep {$_->is_aligned_to($node1, {rel_types => ['int|rule-based']}) } $node1->get_referencing_nodes('alignment');
     }
 
     # If $node1 is aligned, save its alignment as a string to @my_al.

--- a/lib/Treex/Block/Align/PruneAlignmentForProjection.pm
+++ b/lib/Treex/Block/Align/PruneAlignmentForProjection.pm
@@ -53,7 +53,7 @@ sub prune_many_to_one {
 	my ($self, $source_tree, $target_tree) = @_;
 	my @nodes = $target_tree->get_descendants( { ordered => 1 } );
 	foreach my $node (@nodes) {
-		my @referring_nodes = grep{ $_->is_aligned_to($node, {rel_types => ['^'.$self->alignment_type.'$']}) } $node->get_referencing_nodes('alignment');
+		my @referring_nodes = grep{ $_->is_directed_aligned_to($node, {rel_types => ['^'.$self->alignment_type.'$']}) } $node->get_referencing_nodes('alignment');
 		if (scalar(@referring_nodes) > 1) {
 			my @referring_nodes_sorted = sort {$a->ord <=> $b->ord}@referring_nodes;	
 			foreach my $i (0..($#referring_nodes_sorted-1)) {

--- a/lib/Treex/Block/Align/PruneAlignmentForProjection.pm
+++ b/lib/Treex/Block/Align/PruneAlignmentForProjection.pm
@@ -53,7 +53,7 @@ sub prune_many_to_one {
 	my ($self, $source_tree, $target_tree) = @_;
 	my @nodes = $target_tree->get_descendants( { ordered => 1 } );
 	foreach my $node (@nodes) {
-		my @referring_nodes = grep{ $_->is_aligned_to($node, '^' . $self->alignment_type . '$')}$node->get_referencing_nodes('alignment');
+		my @referring_nodes = grep{ $_->is_aligned_to($node, {rel_types => ['^'.$self->alignment_type.'$']}) } $node->get_referencing_nodes('alignment');
 		if (scalar(@referring_nodes) > 1) {
 			my @referring_nodes_sorted = sort {$a->ord <=> $b->ord}@referring_nodes;	
 			foreach my $i (0..($#referring_nodes_sorted-1)) {

--- a/lib/Treex/Block/Align/RemoveAlignments.pm
+++ b/lib/Treex/Block/Align/RemoveAlignments.pm
@@ -12,7 +12,7 @@ sub process_zone {
 	my $tree = $zone->get_tree($self->layer);
 	my @nodes = $tree->get_descendants({ordered=>1});
 	foreach my $n (@nodes) {
-		my ($aligned_nodes_ref, $types_ref) = $n->get_aligned_nodes();
+		my ($aligned_nodes_ref, $types_ref) = $n->get_directed_aligned_nodes();
 		if (defined $aligned_nodes_ref) {
 			my @aligned_nodes = @{$aligned_nodes_ref};	
 			map{$n->delete_aligned_node($_, $self->alignment_type)}@aligned_nodes;

--- a/lib/Treex/Block/Align/ReverseAlignment.pm
+++ b/lib/Treex/Block/Align/ReverseAlignment.pm
@@ -20,7 +20,7 @@ sub process_zone {
     my @nodes = $zone->get_tree( $self->layer )->get_descendants( { ordered => 1 } );
 
     foreach my $x (@nodes) {
-		my ( $n_rf, $t_rf ) = $x->get_aligned_nodes();
+		my ( $n_rf, $t_rf ) = $x->get_directed_aligned_nodes();
         if ($self->reverse_align_type and $t_rf) {
             my $iterator = List::MoreUtils::each_arrayref( $n_rf, $t_rf );
             while ( my ( $y, $type ) = $iterator->() ) {

--- a/lib/Treex/Block/Align/T/AlignCzechPersprons.pm
+++ b/lib/Treex/Block/Align/T/AlignCzechPersprons.pm
@@ -15,7 +15,7 @@ sub process_ttree {
         if ($t_node->is_generated) {
             my ($eparent) = $t_node->get_eparents;
             next if !$eparent;
-            my ($en_tnodes, $types) = $eparent->get_aligned_nodes;
+            my ($en_tnodes, $types) = $eparent->get_directed_aligned_nodes;
             my ($en_eparent) = map {$$en_tnodes[$_]} grep {$$types[$_] =~ /int/} (0 .. $#$en_tnodes);
             next if !$en_eparent;
             foreach my $en_child ($en_eparent->get_echildren) {

--- a/lib/Treex/Block/Align/T/AlignGeneratedNodes.pm
+++ b/lib/Treex/Block/Align/T/AlignGeneratedNodes.pm
@@ -107,7 +107,7 @@ sub score {
 
     my $src_par = $src_node->get_parent;
     
-    $feature_vector{aligned_parent} = $src_par->is_aligned_to($trg_node->get_parent, {rel_types => ['monolingual']}) ? 1 : 0;
+    $feature_vector{aligned_parent} = $src_par->is_directed_aligned_to($trg_node->get_parent, {rel_types => ['monolingual']}) ? 1 : 0;
     
     my @src_eparents = $src_node->get_eparents;
     my @trg_eparents = $trg_node->get_eparents;

--- a/lib/Treex/Block/Align/T/AlignGeneratedNodes.pm
+++ b/lib/Treex/Block/Align/T/AlignGeneratedNodes.pm
@@ -107,7 +107,7 @@ sub score {
 
     my $src_par = $src_node->get_parent;
     
-    $feature_vector{aligned_parent} = $src_par->is_aligned_to($trg_node->get_parent, 'monolingual') ? 1 : 0;
+    $feature_vector{aligned_parent} = $src_par->is_aligned_to($trg_node->get_parent, {rel_types => ['monolingual']}) ? 1 : 0;
     
     my @src_eparents = $src_node->get_eparents;
     my @trg_eparents = $trg_node->get_eparents;

--- a/lib/Treex/Block/Align/T/Compare.pm
+++ b/lib/Treex/Block/Align/T/Compare.pm
@@ -5,8 +5,6 @@ use Treex::Core::Common;
 
 use Term::ANSIColor;
 
-use Treex::Tool::Align::Utils;
-
 extends 'Treex::Block::Write::BaseTextWriter';
 with 'Treex::Block::Filter::Node::T';
 
@@ -102,8 +100,8 @@ sub _linearize_subtree_recur {
 sub _process_node {
     my ($self, $l1_node) = @_;
     
-    my ($l2_true_nodes, $true_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($l1_node, $self->_true_align_filter);
-    my ($l2_pred_nodes, $pred_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($l1_node, $self->_pred_align_filter);
+    my ($l2_true_nodes, $true_types) = $l1_node->get_undirected_aligned_nodes($self->_true_align_filter);
+    my ($l2_pred_nodes, $pred_types) = $l1_node->get_undirected_aligned_nodes($self->_pred_align_filter);
 
     my %l2_true_ids = map {$_->id => 1} @$l2_true_nodes;
     my %l2_pred_ids = map {$_->id => 1} @$l2_pred_nodes;
@@ -195,7 +193,7 @@ A comma-separated list of the node types to be in focus (see more in C<Treex::Bl
 
 The comma-separated lists of types of alignment links to be compared.
 The format of the lists must satisfy the format required by the C<rel_types> 
-parameter in C<Treex::Tool::Align::Utils>.
+parameter in C<Treex::Core::Node::Aligned>.
 
 =back
 

--- a/lib/Treex/Block/Align/T/CopyAlignmentFromAlayer.pm
+++ b/lib/Treex/Block/Align/T/CopyAlignmentFromAlayer.pm
@@ -51,7 +51,7 @@ sub process_ttree {
     foreach my $tnode ( $troot->get_descendants ) {
         my $anode = $tnode->get_lex_anode;
         next if not $anode;
-        my ( $nodes, $types ) = $anode->get_aligned_nodes();
+        my ( $nodes, $types ) = $anode->get_directed_aligned_nodes();
         foreach my $i ( 0 .. $#$nodes ) {
             next if (keys %{$self->align_type} && !$self->align_type->{$types->[$i]});
             my $to_tnode = $a2t{ $$nodes[$i] } || next;

--- a/lib/Treex/Block/Align/T/Eval.pm
+++ b/lib/Treex/Block/Align/T/Eval.pm
@@ -5,8 +5,6 @@ use Treex::Core::Common;
 
 use List::MoreUtils qw/any/;
 
-use Treex::Tool::Align::Utils;
-
 extends 'Treex::Block::Write::BaseTextWriter';
 with 'Treex::Block::Filter::Node::T';
 
@@ -18,12 +16,18 @@ sub _process_node {
     my ($self, $node) = @_;
     
     # get true and predicted aligned nodes
-    my ($true_nodes, $true_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node,
-        {language => $self->align_language, selector => $self->selector, rel_types => ['gold']});
+    my ($true_nodes, $true_types) = $node->get_undirected_aligned_nodes({
+        language => $self->align_language,
+        selector => $self->selector,
+        rel_types => ['gold'],
+    });
     log_debug "TRUE_TYPES: " . (join " ", @$true_types), 1;
     my @rel_types = split /,/, $self->align_reltypes;
-    my ($pred_nodes, $pred_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node,
-        {language => $self->align_language, selector => $self->selector, rel_types => \@rel_types });
+    my ($pred_nodes, $pred_types) = $node->get_undirected_aligned_nodes({
+        language => $self->align_language,
+        selector => $self->selector,
+        rel_types => \@rel_types,
+    });
     log_debug "PRED_TYPES: " . (join " ", @$pred_types), 1;
    
     # get all candidates for alignment
@@ -103,7 +107,7 @@ A comma-separated list of the node types to be evaluated (see more in C<Treex::B
 =item align_reltypes
 
 The comma-separated list of types of alignment links to be evaluated. The format of the list must satisfy
-the format required by the C<rel_types> parameter in C<Treex::Tool::Align::Utils>.
+the format required by the C<rel_types> parameter in C<Treex::Core::Node::Aligned>.
 
 =item align_language
 

--- a/lib/Treex/Block/Align/T/Greedy1To1Alignment.pm
+++ b/lib/Treex/Block/Align/T/Greedy1To1Alignment.pm
@@ -65,7 +65,7 @@ sub process_bundle {
     my %aligned_by_giza = ();
     if ($self->using_walign) {
         foreach my $cs_anode ( $czech_atree->get_children ) {
-            my ( $nodes, $types ) = $cs_anode->get_aligned_nodes();
+            my ( $nodes, $types ) = $cs_anode->get_directed_aligned_nodes();
             foreach my $i ( 0 .. $#$nodes ) {
                 $aligned_by_giza{$cs_anode}{$$nodes[$i]} = $$types[$i];
             }

--- a/lib/Treex/Block/Align/T/PCEDTAlignment.pm
+++ b/lib/Treex/Block/Align/T/PCEDTAlignment.pm
@@ -31,7 +31,7 @@ sub process_ttree {
     foreach my $tnode ( $troot->get_descendants ) {
         my $anode = $tnode->get_lex_anode;
         next if not $anode;
-        my ( $nodes, $types ) = $anode->get_aligned_nodes();
+        my ( $nodes, $types ) = $anode->get_directed_aligned_nodes();
         foreach my $i ( 0 .. $#$nodes ) {
             my $to_tnode = $a2t{ $$nodes[$i] } || next;
 
@@ -46,7 +46,7 @@ sub process_ttree {
     foreach my $tnode ( $troot->get_descendants ) {
         my $anode = $tnode->get_lex_anode;
         next if not $anode;
-        my ( $nodes, $types ) = $anode->get_aligned_nodes();
+        my ( $nodes, $types ) = $anode->get_directed_aligned_nodes();
         foreach my $i ( 0 .. $#$nodes ) {
             my $to_tnode = $a2t{ $$nodes[$i] } || next;
 
@@ -62,7 +62,7 @@ sub process_ttree {
     # connect other not yet aligned nodes, that have the same functor and their parents are aligned
     foreach my $tnode ( $troot->get_descendants ) {
         next if $is_aligned{$tnode};
-        my ( $nodes, $types ) = $tnode->get_parent->get_aligned_nodes();
+        my ( $nodes, $types ) = $tnode->get_parent->get_directed_aligned_nodes();
         next if !$nodes || !@$nodes;
         next if !$is_aligned{ $$nodes[0] };
         foreach my $candidate ( $$nodes[0]->get_children() ) {

--- a/lib/Treex/Block/Align/T/Supervised/Resolver.pm
+++ b/lib/Treex/Block/Align/T/Supervised/Resolver.pm
@@ -98,14 +98,11 @@ sub _finalize_links {
     foreach my $from_id (sort keys %$links) {
         my $from_node = $bundle->get_document->get_node_by_id($from_id);
         if ($self->delete_orig_align) {
-            Treex::Tool::Align::Utils::remove_aligned_nodes_by_filter(
-                $from_node, 
-                {
-                    language => $self->_get_align_lang($from_node->language),
-                    selector => $self->selector, 
-                    rel_types => ['!gold','.*']
-                }
-            );
+            $from_node->delete_aligned_nodes_by_filter({
+                language => $self->_get_align_lang($from_node->language),
+                selector => $self->selector, 
+                rel_types => ['!gold','.*'],
+            });
         }
         foreach my $to_id (sort keys %{$links->{$from_id}}) {
             my $to_node = $bundle->get_document->get_node_by_id($to_id);

--- a/lib/Treex/Block/Depfix/CS2EN/FixGenitive.pm
+++ b/lib/Treex/Block/Depfix/CS2EN/FixGenitive.pm
@@ -9,7 +9,7 @@ sub fix {
 
     return if !defined $al_child;
     my ($al_parent) = $al_child->get_eparents();
-    #my ($al_al_parent) = $al_parent->get_aligned_nodes();
+    #my ($al_al_parent) = $al_parent->get_directed_aligned_nodes();
 
     if ($al_child->tag =~ /^N...2/
         && $al_parent->tag =~ /^N/

--- a/lib/Treex/Block/Eval/AER.pm
+++ b/lib/Treex/Block/Eval/AER.pm
@@ -37,14 +37,14 @@ sub process_atree {
 		my @target_nodes;
 		my @gold_nodes;
 		if ($self->target_alignment_direction eq 'trg2src') {
-			@target_nodes = grep {$_->is_aligned_to($node, {rel_types => ['^'.$self->target_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->target_selector);
+			@target_nodes = grep {$_->is_directed_aligned_to($node, {rel_types => ['^'.$self->target_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->target_selector);
 		}
 		else {
 			@target_nodes = $node->get_aligned_nodes_of_type('^' . $self->target_alignment_type . '$', $self->target_language, $self->target_selector);			
 		}
 		
 		if ($self->gold_alignment_direction eq 'trg2src') {
-			@gold_nodes = grep {$_->is_aligned_to($node, {rel_types => ['^'.$self->gold_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->gold_selector);
+			@gold_nodes = grep {$_->is_directed_aligned_to($node, {rel_types => ['^'.$self->gold_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->gold_selector);
 		}
 		else {
 			@gold_nodes = $node->get_aligned_nodes_of_type('^' . $self->gold_alignment_type . '$', $self->target_language, $self->gold_selector);

--- a/lib/Treex/Block/Eval/AER.pm
+++ b/lib/Treex/Block/Eval/AER.pm
@@ -37,14 +37,14 @@ sub process_atree {
 		my @target_nodes;
 		my @gold_nodes;
 		if ($self->target_alignment_direction eq 'trg2src') {
-			@target_nodes = grep {$_->is_aligned_to($node, '^' . $self->target_alignment_type . '$')} $node->get_referencing_nodes('alignment', $self->target_language, $self->target_selector);
+			@target_nodes = grep {$_->is_aligned_to($node, {rel_types => ['^'.$self->target_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->target_selector);
 		}
 		else {
 			@target_nodes = $node->get_aligned_nodes_of_type('^' . $self->target_alignment_type . '$', $self->target_language, $self->target_selector);			
 		}
 		
 		if ($self->gold_alignment_direction eq 'trg2src') {
-			@gold_nodes = grep {$_->is_aligned_to($node, '^' . $self->gold_alignment_type . '$')} $node->get_referencing_nodes('alignment', $self->target_language, $self->gold_selector);
+			@gold_nodes = grep {$_->is_aligned_to($node, {rel_types => ['^'.$self->gold_alignment_type.'$']})} $node->get_referencing_nodes('alignment', $self->target_language, $self->gold_selector);
 		}
 		else {
 			@gold_nodes = $node->get_aligned_nodes_of_type('^' . $self->gold_alignment_type . '$', $self->target_language, $self->gold_selector);

--- a/lib/Treex/Block/Eval/AddPersPronIt.pm
+++ b/lib/Treex/Block/Eval/AddPersPronIt.pm
@@ -187,7 +187,7 @@ sub analyze_en {
                 else {
                     $non_anaph_sum++;
                 }
-                my ($aligned, $types) = $t_node->get_aligned_nodes;
+                my ($aligned, $types) = $t_node->get_directed_aligned_nodes;
                 if ( $aligned and $types->[0] ne "monolingual" ) {
     #                     $cs_node = $aligned->[0];
     #                         $cs_node->t_lemma eq "ten" ) {
@@ -201,7 +201,7 @@ sub analyze_en {
             }
             else {
                 $pleon_sum++;
-                my ($aligned, $types) = $t_node->get_aligned_nodes;
+                my ($aligned, $types) = $t_node->get_directed_aligned_nodes;
                 if ( $aligned and $types->[0] ne "monolingual" ) {
                     $cs_node = $aligned->[0];
                     if ( Treex::Block::Eval::AddPersPronSb::has_pleon_sb($cs_node) ) {
@@ -467,7 +467,7 @@ sub analyze_cs {
 
 sub get_aligned_node {
     my ( $t_node ) = @_;
-    my ($aligned, $types) = $t_node->get_aligned_nodes;
+    my ($aligned, $types) = $t_node->get_directed_aligned_nodes;
     if ( $types ) {
         my $i;
         for ( $i = 0; $i < @{$types}; $i++ ) {
@@ -501,7 +501,7 @@ sub get_en2cs_links {
     my ( $cs_tree ) = @_;
     my %en2cs_node;
     foreach my $cs_node ( $cs_tree->get_descendants ) {
-        my ($aligned, $types) = $cs_node->get_aligned_nodes;
+        my ($aligned, $types) = $cs_node->get_directed_aligned_nodes;
         foreach my $en_node ( @{$aligned} ) {
             $en2cs_node{$en_node} = $cs_node;
         }
@@ -514,7 +514,7 @@ sub get_cs2en_links {
     my ( $en_tree ) = @_;
     my %cs2en_node;
     foreach my $en_node ( $en_tree->get_descendants ) {
-        my ($aligned, $types) = $en_node->get_aligned_nodes;
+        my ($aligned, $types) = $en_node->get_directed_aligned_nodes;
         if ( $aligned ) {
             for ( my $i = 0; $i < @$aligned; $i++ ) {
                 $cs2en_node{$aligned->[$i]} = $en_node if ( $types->[$i] ne "monolingual" );
@@ -1490,7 +1490,7 @@ sub test_it_cs {
 
 sub has_en_perspron {
     my ( $cs_verb ) = @_;
-    my ($aligned, $types) = $cs_verb->get_aligned_nodes;
+    my ($aligned, $types) = $cs_verb->get_directed_aligned_nodes;
 #     my $en_verb = get_aligned_node($cs_verb);
 #     if ( $aligned ) {
     my $i = 0;
@@ -1520,7 +1520,7 @@ sub has_en_perspron {
 
 sub has_en_sb {
     my ( $cs_verb ) = @_;
-    my ($aligned, $types) = $cs_verb->get_aligned_nodes;
+    my ($aligned, $types) = $cs_verb->get_directed_aligned_nodes;
     my $i = 0;
     while ( $aligned->[$i] ) {
         if ( ($aligned->[$i]->gram_sempos || "") eq "v" ) {

--- a/lib/Treex/Block/Eval/AddPersPronSb.pm
+++ b/lib/Treex/Block/Eval/AddPersPronSb.pm
@@ -222,7 +222,7 @@ my $total_sum = 0;
 
 sub get_aligned_node {
     my ( $t_node ) = @_;
-    my ($aligned, $types) = $t_node->get_aligned_nodes;
+    my ($aligned, $types) = $t_node->get_directed_aligned_nodes;
     return ( $aligned->[0] ) ? $aligned->[0] : "";
 }
 

--- a/lib/Treex/Block/Eval/BiEdgeScore.pm
+++ b/lib/Treex/Block/Eval/BiEdgeScore.pm
@@ -18,7 +18,7 @@ sub process_atree {
     my @nodes = $root->get_descendants( { ordered => 1 } );
     my %alignment;
 	foreach my $node (@nodes) {
-        my ($alinodes, $alitypes) = $node->get_aligned_nodes;
+        my ($alinodes, $alitypes) = $node->get_directed_aligned_nodes;
         foreach my $i (0 .. $#$alinodes) {
             if ($$alitypes[$i] =~ /int/) {
                 $alignment{$node} = $$alinodes[$i];

--- a/lib/Treex/Block/Eval/BitextCorefStats.pm
+++ b/lib/Treex/Block/Eval/BitextCorefStats.pm
@@ -17,7 +17,7 @@ sub process_tnode {
 
 
     if ($self->filter->is_candidate( $tnode )) {
-        my ($nodes, $types) = $tnode->get_aligned_nodes;
+        my ($nodes, $types) = $tnode->get_directed_aligned_nodes;
 
         # PRINTING THE COUNT OF ALIGNED NODES
         #if (!$nodes) {
@@ -40,7 +40,7 @@ sub process_tnode {
             #}
 
             if ($lemma eq '#PersPron') {
-                my @antes_align_en = map {my ($nodes, $types) = $_->get_aligned_nodes; $nodes ? @$nodes : ()} $tnode->get_coref_nodes;
+                my @antes_align_en = map {my ($nodes, $types) = $_->get_directed_aligned_nodes; $nodes ? @$nodes : ()} $tnode->get_coref_nodes;
                 my %antes_en_hash = map {$_->id => 1} $en_node->get_coref_nodes;
 
                 my @in_common = grep {$antes_en_hash{$_->id}} @antes_align_en;

--- a/lib/Treex/Block/Eval/Coref.pm
+++ b/lib/Treex/Block/Eval/Coref.pm
@@ -92,7 +92,7 @@ sub _get_corresponding_node {
 
     my $src_node = $ref_node->src_tnode;
     if (!defined $src_node) {
-        my ($aligned, $types) = $ref_node->get_aligned_nodes;
+        my ($aligned, $types) = $ref_node->get_directed_aligned_nodes;
         $src_node = $aligned->[0];
         if (@$aligned > 1) {
             print STDERR "MORE THAN ONE ALIGNED NODE: ". $ref_node->id. " -> " .(join ", ", (map {$_->id} @$aligned)). "\n";

--- a/lib/Treex/Block/Misc/CopenhagenDT/MoveTLTreesToSLCounterpartByAlignment.pm
+++ b/lib/Treex/Block/Misc/CopenhagenDT/MoveTLTreesToSLCounterpartByAlignment.pm
@@ -24,7 +24,7 @@ sub process_document {
             my %alignments_per_da_tree;
             foreach my $node ($tree->get_descendants({add_self=>1})) {
 
-                my ($nodes_rf, $types_rf) = $node->get_aligned_nodes;
+                my ($nodes_rf, $types_rf) = $node->get_directed_aligned_nodes;
 
                 if (defined $nodes_rf and scalar @{$nodes_rf} > 0) {
                     foreach my $index (0..$#{$nodes_rf}) {

--- a/lib/Treex/Block/Misc/CopenhagenDT/MoveTreesToDanishCounterpartByAlignment.pm
+++ b/lib/Treex/Block/Misc/CopenhagenDT/MoveTreesToDanishCounterpartByAlignment.pm
@@ -25,7 +25,7 @@ print STDERR "XXXX $SourceLanguage\n";
             my %alignments_per_da_tree;
             foreach my $node ($tree->get_descendants({add_self=>1})) {
 
-                my ($nodes_rf, $types_rf) = $node->get_aligned_nodes;
+                my ($nodes_rf, $types_rf) = $node->get_directed_aligned_nodes;
 
                 if (defined $nodes_rf and scalar @{$nodes_rf} > 0) {
 

--- a/lib/Treex/Block/Misc/CopenhagenDT/PrintExtraction4Miriam.pm
+++ b/lib/Treex/Block/Misc/CopenhagenDT/PrintExtraction4Miriam.pm
@@ -27,7 +27,7 @@ sub process_bundle {
 
     my $alignments = '';
     foreach my $second_lang_node ($second_lang_atree->get_descendants) {
-        my ($alignment_links_rf, $alignment_types_rf) = $second_lang_node->get_aligned_nodes;
+        my ($alignment_links_rf, $alignment_types_rf) = $second_lang_node->get_directed_aligned_nodes;
         if ($alignment_links_rf) {
             my @da_indices;
 

--- a/lib/Treex/Block/Misc/CopenhagenDT/SearchDemo.pm
+++ b/lib/Treex/Block/Misc/CopenhagenDT/SearchDemo.pm
@@ -33,7 +33,7 @@ sub process_bundle {
 
 sub _get_first_aligned_node {
     my ($self,$node) = @_;
-    my ($aligned_nodes_rf,$aligned_types_rf) = $node->get_aligned_nodes;
+    my ($aligned_nodes_rf,$aligned_types_rf) = $node->get_directed_aligned_nodes;
     return undef if not defined $aligned_types_rf;
     my ($first) = @$aligned_nodes_rf;
     return $first;

--- a/lib/Treex/Block/Misc/CopenhagenDT/SearchSwitched.pm
+++ b/lib/Treex/Block/Misc/CopenhagenDT/SearchSwitched.pm
@@ -15,11 +15,11 @@ sub process_bundle {
     for my $zone ($bundle->get_all_zones) {
         my $atree = $zone->get_atree;
         for my $node ($zone->get_atree->get_descendants) {
-            my ($nodes, $types) = $node->get_aligned_nodes;
+            my ($nodes, $types) = $node->get_directed_aligned_nodes;
             next unless $nodes;
             my $following = $node->get_next_node;
             next unless $following;
-            my ($f_nodes, $f_types) = $following->get_aligned_nodes;
+            my ($f_nodes, $f_types) = $following->get_directed_aligned_nodes;
             next unless $f_nodes;
 
             my ($align1, $align2);

--- a/lib/Treex/Block/Misc/ProjectAndConcatAttribs.pm
+++ b/lib/Treex/Block/Misc/ProjectAndConcatAttribs.pm
@@ -7,7 +7,7 @@ extends 'Treex::Core::Block';
 sub process_tnode {
     my ( $self, $cs_tnode ) = @_;
 
-    my ($aligned_nodes_rf,$types_rf) = $cs_tnode->get_aligned_nodes;
+    my ($aligned_nodes_rf,$types_rf) = $cs_tnode->get_directed_aligned_nodes;
     foreach my $en_tnode (@$aligned_nodes_rf) {
         $en_tnode->set_t_lemma($en_tnode->t_lemma.'='.$cs_tnode->t_lemma);
         $en_tnode->set_formeme($en_tnode->formeme.'='.$cs_tnode->formeme);

--- a/lib/Treex/Block/Misc/Translog/MergeSentencesByAlignment.pm
+++ b/lib/Treex/Block/Misc/Translog/MergeSentencesByAlignment.pm
@@ -15,7 +15,7 @@ sub process_document {
         foreach my $da_node ($bundle->get_zone('da')->get_atree->get_descendants) {
 
             # find the first aligned node, and move all nodes to
-            my ($nodes_rf, $types_rf) = $da_node->get_aligned_nodes;
+            my ($nodes_rf, $types_rf) = $da_node->get_directed_aligned_nodes;
 
             if (defined $nodes_rf) {
                 my ($aligned_en_node) = @$nodes_rf;

--- a/lib/Treex/Block/Misc/Translog/RemakeWildZones.pm
+++ b/lib/Treex/Block/Misc/Translog/RemakeWildZones.pm
@@ -73,7 +73,7 @@ sub process_document {
 						$in_value{"$diff:$deprel"}=1;
 						
 					}
-					my ($nodes_rf,$typ_ref) = $node->get_aligned_nodes();
+					my ($nodes_rf,$typ_ref) = $node->get_directed_aligned_nodes();
 					
 					if (defined $nodes_rf){
 						my @ref_nodes = @{$nodes_rf};

--- a/lib/Treex/Block/Misc/Translog/SegmentSentences.pm
+++ b/lib/Treex/Block/Misc/Translog/SegmentSentences.pm
@@ -40,7 +40,7 @@ sub process_document {
             }
 
             else { # otherwise we search for the English boundary by alignment
-                my ($nodes_rf, $types_rf) = $da_sentence_end_node->get_aligned_nodes;
+                my ($nodes_rf, $types_rf) = $da_sentence_end_node->get_directed_aligned_nodes;
                 if ($nodes_rf) {
                     ($en_sentence_end_node) = @$nodes_rf;
                 }

--- a/lib/Treex/Block/Print/AlignedFrames.pm
+++ b/lib/Treex/Block/Print/AlignedFrames.pm
@@ -10,7 +10,7 @@ sub process_tnode {
     my ($self, $tnode) = @_;
 
     my $id = $tnode->get_attr('val_frame.rf') or return;
-    my ($aligns, $types) = $tnode->get_aligned_nodes();
+    my ($aligns, $types) = $tnode->get_directed_aligned_nodes();
     return if !$aligns;
     my ($al_tnode) = @$aligns;
 

--- a/lib/Treex/Block/Print/AlignmentStatistics.pm
+++ b/lib/Treex/Block/Print/AlignmentStatistics.pm
@@ -81,7 +81,7 @@ sub get_local_stat {
 				elsif ( scalar(@aligned_nodes) == 1 ) {
 					my @referring_nodes = grep {
 						$_->is_aligned_to( $aligned_nodes[0],
-							'^' . $self->alignment_type . '$' )
+							{rel_types => ['^'.$self->alignment_type.'$']} )
 					  } $aligned_nodes[0]->get_referencing_nodes( 'alignment',
 						$self->source_language, $self->source_selector );
 					if ( scalar(@referring_nodes) == 1 ) {
@@ -98,7 +98,7 @@ sub get_local_stat {
 		foreach my $j ( 0 .. $#tgt_nodes ) {
 			my @referring_nodes = grep {
 				$_->is_aligned_to( $tgt_nodes[$j],
-					'^' . $self->alignment_type . '$' )
+					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $tgt_nodes[$j]
 			  ->get_referencing_nodes( 'alignment', $self->source_language,
 				$self->source_selector );
@@ -130,7 +130,7 @@ sub get_local_stat {
 		foreach my $i ( 0 .. $#src_nodes ) {
 			my @referring_nodes = grep {
 				$_->is_aligned_to( $src_nodes[$i],
-					'^' . $self->alignment_type . '$' )
+					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $src_nodes[$i]
 			  ->get_referencing_nodes( 'alignment', $self->language,
 				$self->selector );
@@ -170,7 +170,7 @@ sub get_local_stat {
 					foreach my $an (@aligned_nodes) {
 						my @referring_nodes = grep {
 							$_->is_aligned_to( $an,
-								'^' . $self->alignment_type . '$' )
+								{rel_types => ['^'.$self->alignment_type.'$']} )
 						  } $an->get_referencing_nodes( 'alignment',
 							$self->language, $self->selector );
 						if ( scalar( @referring_nodes != 1 ) ) {

--- a/lib/Treex/Block/Print/AlignmentStatistics.pm
+++ b/lib/Treex/Block/Print/AlignmentStatistics.pm
@@ -80,7 +80,7 @@ sub get_local_stat {
 				}
 				elsif ( scalar(@aligned_nodes) == 1 ) {
 					my @referring_nodes = grep {
-						$_->is_aligned_to( $aligned_nodes[0],
+						$_->is_directed_aligned_to( $aligned_nodes[0],
 							{rel_types => ['^'.$self->alignment_type.'$']} )
 					  } $aligned_nodes[0]->get_referencing_nodes( 'alignment',
 						$self->source_language, $self->source_selector );
@@ -97,7 +97,7 @@ sub get_local_stat {
 		}
 		foreach my $j ( 0 .. $#tgt_nodes ) {
 			my @referring_nodes = grep {
-				$_->is_aligned_to( $tgt_nodes[$j],
+				$_->is_directed_aligned_to( $tgt_nodes[$j],
 					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $tgt_nodes[$j]
 			  ->get_referencing_nodes( 'alignment', $self->source_language,
@@ -129,7 +129,7 @@ sub get_local_stat {
 	else {
 		foreach my $i ( 0 .. $#src_nodes ) {
 			my @referring_nodes = grep {
-				$_->is_aligned_to( $src_nodes[$i],
+				$_->is_directed_aligned_to( $src_nodes[$i],
 					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $src_nodes[$i]
 			  ->get_referencing_nodes( 'alignment', $self->language,
@@ -169,7 +169,7 @@ sub get_local_stat {
 					my $is_m_to_1 = 1;
 					foreach my $an (@aligned_nodes) {
 						my @referring_nodes = grep {
-							$_->is_aligned_to( $an,
+							$_->is_directed_aligned_to( $an,
 								{rel_types => ['^'.$self->alignment_type.'$']} )
 						  } $an->get_referencing_nodes( 'alignment',
 							$self->language, $self->selector );

--- a/lib/Treex/Block/Print/EvalAlignedAtrees.pm
+++ b/lib/Treex/Block/Print/EvalAlignedAtrees.pm
@@ -17,13 +17,13 @@ my $err_nodes = 0;
 sub process_anode {
     my ( $self, $node, $bundleNo ) = @_;
     $all_nodes++;
-    my ($n) = $node->get_aligned_nodes;
+    my ($n) = $node->get_directed_aligned_nodes;
     log_fatal 'Node ' . $node->get_address . ' has no aligned nodes' if !$n;
     my ($a) = @$n;
     return if $node->get_parent->is_root && $a->get_parent->is_root;
     return $self->report_error( $node, $bundleNo ) if $node->get_parent->is_root || $a->get_parent->is_root;
 
-    my ($pn) = $node->get_parent->get_aligned_nodes;
+    my ($pn) = $node->get_parent->get_directed_aligned_nodes;
     return $self->report_error( $node, $bundleNo ) if !$pn;
     my ($pa) = @$pn;
     return $self->report_error( $node, $bundleNo ) if $a->parent != $pa;

--- a/lib/Treex/Block/Print/ItTranslData.pm
+++ b/lib/Treex/Block/Print/ItTranslData.pm
@@ -64,7 +64,7 @@ sub _csrefs_from_ensrc {
     my ($self, $ensrc) = @_;
     
     # moving to "en-ref" nodes via monolingual alignment
-    my @enrefs = grep {$_->is_aligned_to($ensrc, {rel_types => ['monolingual']})} $ensrc->get_referencing_nodes('alignment');
+    my @enrefs = grep {$_->is_directed_aligned_to($ensrc, {rel_types => ['monolingual']})} $ensrc->get_referencing_nodes('alignment');
     return [] if ( @enrefs == 0 );
     
     # getting all nodes aligned with the first "en-ref"
@@ -79,9 +79,9 @@ sub _csrefs_from_ensrc {
 sub _get_aligned_nodes_czeng {
     my ($self, $tnode) = @_;
 
-    my @t_cssrc = grep {!$_->is_aligned_to($tnode, {rel_types => ['monolingual']})} $tnode->get_referencing_nodes('alignment');
+    my @t_cssrc = grep {!$_->is_directed_aligned_to($tnode, {rel_types => ['monolingual']})} $tnode->get_referencing_nodes('alignment');
     my $anode = $tnode->get_lex_anode;
-    my @a_cssrc = grep {!$_->is_aligned_to($anode, {rel_types => ['monolingual']})} $anode->get_referencing_nodes('alignment');
+    my @a_cssrc = grep {!$_->is_directed_aligned_to($anode, {rel_types => ['monolingual']})} $anode->get_referencing_nodes('alignment');
     return (\@t_cssrc, \@a_cssrc);
 }
 
@@ -109,7 +109,7 @@ sub _get_gold_counterpart_tlemma {
     my ($self, $ensrc_it) = @_;
     
     my $a_ensrc_it = $ensrc_it->get_lex_anode;
-    my ($a_enref_it) = grep {$_->is_aligned_to($a_ensrc_it, {rel_types => ['monolingual']})} $a_ensrc_it->get_referencing_nodes('alignment');
+    my ($a_enref_it) = grep {$_->is_directed_aligned_to($a_ensrc_it, {rel_types => ['monolingual']})} $a_ensrc_it->get_referencing_nodes('alignment');
     return "__NO_A_ENREF__" if !$a_enref_it;
     my ($enref_it) = $a_enref_it->get_referencing_nodes('a/lex.rf');
     return "__NO_T_ENREF__" if !$enref_it;

--- a/lib/Treex/Block/Print/ItTranslData.pm
+++ b/lib/Treex/Block/Print/ItTranslData.pm
@@ -68,7 +68,7 @@ sub _csrefs_from_ensrc {
     return [] if ( @enrefs == 0 );
     
     # getting all nodes aligned with the first "en-ref"
-    my ($aligns, $type) = $enrefs[0]->get_aligned_nodes;
+    my ($aligns, $type) = $enrefs[0]->get_directed_aligned_nodes;
     return [] if (!$aligns || !$type);
     
     # collecting all aligned nodes except for those monolingually aligned - supposed to be "cs-ref"
@@ -116,7 +116,7 @@ sub _get_gold_counterpart_tlemma {
 
     my ($enref_par) = grep {$_->formeme && ($_->formeme =~ /^v/)} $enref_it->get_eparents;
     return "__NO_V_ENREF_PAR__" if !$enref_par;
-    my ($aligns, $type) = $enref_par->get_aligned_nodes;
+    my ($aligns, $type) = $enref_par->get_directed_aligned_nodes;
     return "__NO_CSREF_PAR__" if (!$aligns || !$type);
         
     my ($csref_par) = grep {$_->formeme =~ /^v/} map {$aligns->[$_]} grep {$type->[$_] ne 'monolingual'} (0 .. @$aligns-1);
@@ -133,7 +133,7 @@ sub _gold_counterpart_tlemma_via_alayer {
     my ($a_enref_par) = grep {defined $_->tag && ($_->tag =~ /^V/)} $a_enref_it->get_eparents;
     return "__A:NO_A_V_ENREF_PAR__" if !$a_enref_par;
 
-    my ($aligns, $type) = $a_enref_par->get_aligned_nodes;
+    my ($aligns, $type) = $a_enref_par->get_directed_aligned_nodes;
     return "__A:NO_A_CSREF_PAR1__" if (!$aligns || !$type);
     my ($a_csref_par) = map {$aligns->[$_]} grep {$type->[$_] ne 'monolingual'} (0 .. @$aligns-1);
     return "__A:NO_A_CSREF_PAR2__" if !$a_csref_par;

--- a/lib/Treex/Block/Print/ItTranslData.pm
+++ b/lib/Treex/Block/Print/ItTranslData.pm
@@ -64,7 +64,7 @@ sub _csrefs_from_ensrc {
     my ($self, $ensrc) = @_;
     
     # moving to "en-ref" nodes via monolingual alignment
-    my @enrefs = grep {$_->is_aligned_to($ensrc, 'monolingual')} $ensrc->get_referencing_nodes('alignment');
+    my @enrefs = grep {$_->is_aligned_to($ensrc, {rel_types => ['monolingual']})} $ensrc->get_referencing_nodes('alignment');
     return [] if ( @enrefs == 0 );
     
     # getting all nodes aligned with the first "en-ref"
@@ -79,9 +79,9 @@ sub _csrefs_from_ensrc {
 sub _get_aligned_nodes_czeng {
     my ($self, $tnode) = @_;
 
-    my @t_cssrc = grep {!$_->is_aligned_to($tnode, 'monolingual')} $tnode->get_referencing_nodes('alignment');
+    my @t_cssrc = grep {!$_->is_aligned_to($tnode, {rel_types => ['monolingual']})} $tnode->get_referencing_nodes('alignment');
     my $anode = $tnode->get_lex_anode;
-    my @a_cssrc = grep {!$_->is_aligned_to($anode, 'monolingual')} $anode->get_referencing_nodes('alignment');
+    my @a_cssrc = grep {!$_->is_aligned_to($anode, {rel_types => ['monolingual']})} $anode->get_referencing_nodes('alignment');
     return (\@t_cssrc, \@a_cssrc);
 }
 
@@ -109,7 +109,7 @@ sub _get_gold_counterpart_tlemma {
     my ($self, $ensrc_it) = @_;
     
     my $a_ensrc_it = $ensrc_it->get_lex_anode;
-    my ($a_enref_it) = grep {$_->is_aligned_to($a_ensrc_it, 'monolingual')} $a_ensrc_it->get_referencing_nodes('alignment');
+    my ($a_enref_it) = grep {$_->is_aligned_to($a_ensrc_it, {rel_types => ['monolingual']})} $a_ensrc_it->get_referencing_nodes('alignment');
     return "__NO_A_ENREF__" if !$a_enref_it;
     my ($enref_it) = $a_enref_it->get_referencing_nodes('a/lex.rf');
     return "__NO_T_ENREF__" if !$enref_it;

--- a/lib/Treex/Block/Print/TagChanges.pm
+++ b/lib/Treex/Block/Print/TagChanges.pm
@@ -21,7 +21,7 @@ my %total;
 
 sub process_anode {
     my ($self, $anode) = @_;
-    my ($nodes, $types) = $anode->get_aligned_nodes;
+    my ($nodes, $types) = $anode->get_directed_aligned_nodes;
     my $anode2 = $nodes->[0];
     if ($anode2) {
         return if $anode->lemma ne $anode2->lemma;

--- a/lib/Treex/Block/Print/VectorsForTM.pm
+++ b/lib/Treex/Block/Print/VectorsForTM.pm
@@ -71,7 +71,7 @@ sub _build_feature_extractor {
 
 sub process_tnode {
     my ( $self, $ali_src_tnode ) = @_;
-    my ($ali_trg_tnodes_rf, $ali_types_rf) = $ali_src_tnode->get_aligned_nodes();
+    my ($ali_trg_tnodes_rf, $ali_types_rf) = $ali_src_tnode->get_directed_aligned_nodes();
     for my $i (0 .. $#{$ali_trg_tnodes_rf}) {
         my $types = $ali_types_rf->[$i];
         if ($types =~ /int|tali/){

--- a/lib/Treex/Block/Project/Attributes.pm
+++ b/lib/Treex/Block/Project/Attributes.pm
@@ -23,7 +23,7 @@ sub process_zone {
             @src_nodes = $node->get_aligned_nodes_of_type($self->alignment_type);
             
         } else {
-            @src_nodes = grep {$_->is_aligned_to($node, $self->alignment_type)}
+            @src_nodes = grep {$_->is_aligned_to($node, {rel_types => [$self->alignment_type]})}
                          $node->get_referencing_nodes('alignment');
         }
 

--- a/lib/Treex/Block/Project/Attributes.pm
+++ b/lib/Treex/Block/Project/Attributes.pm
@@ -23,7 +23,7 @@ sub process_zone {
             @src_nodes = $node->get_aligned_nodes_of_type($self->alignment_type);
             
         } else {
-            @src_nodes = grep {$_->is_aligned_to($node, {rel_types => [$self->alignment_type]})}
+            @src_nodes = grep {$_->is_directed_aligned_to($node, {rel_types => [$self->alignment_type]})}
                          $node->get_referencing_nodes('alignment');
         }
 

--- a/lib/Treex/Block/Project/Coreference.pm
+++ b/lib/Treex/Block/Project/Coreference.pm
@@ -33,7 +33,7 @@ sub get_aligned {
     if ($is_src xor $self->alignment_direction eq 'trg2src'){
         @aligned = $node->get_aligned_nodes_of_type($self->alignment_type);
     } else {
-        @aligned = grep {$_->is_aligned_to($node, $self->alignment_type)}
+        @aligned = grep {$_->is_aligned_to($node, {rel_types => [$self->alignment_type]})}
                    $node->get_referencing_nodes('alignment');
     }
     return if !@aligned;

--- a/lib/Treex/Block/Project/Coreference.pm
+++ b/lib/Treex/Block/Project/Coreference.pm
@@ -33,7 +33,7 @@ sub get_aligned {
     if ($is_src xor $self->alignment_direction eq 'trg2src'){
         @aligned = $node->get_aligned_nodes_of_type($self->alignment_type);
     } else {
-        @aligned = grep {$_->is_aligned_to($node, {rel_types => [$self->alignment_type]})}
+        @aligned = grep {$_->is_directed_aligned_to($node, {rel_types => [$self->alignment_type]})}
                    $node->get_referencing_nodes('alignment');
     }
     return if !@aligned;

--- a/lib/Treex/Block/Project/Tree.pm
+++ b/lib/Treex/Block/Project/Tree.pm
@@ -101,7 +101,7 @@ sub project_subtree {
 		my @trg_nodes;
 		if ( $self->alignment_direction eq 'trg2src' ) {
 			@trg_nodes = grep {
-				$_->is_aligned_to( $src_node,
+				$_->is_directed_aligned_to( $src_node,
 					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $src_node->get_referencing_nodes( 'alignment', $self->language,
 				$self->selector );

--- a/lib/Treex/Block/Project/Tree.pm
+++ b/lib/Treex/Block/Project/Tree.pm
@@ -102,7 +102,7 @@ sub project_subtree {
 		if ( $self->alignment_direction eq 'trg2src' ) {
 			@trg_nodes = grep {
 				$_->is_aligned_to( $src_node,
-					'^' . $self->alignment_type . '$' )
+					{rel_types => ['^'.$self->alignment_type.'$']} )
 			  } $src_node->get_referencing_nodes( 'alignment', $self->language,
 				$self->selector );
 		}

--- a/lib/Treex/Block/Sample/Trees.pm
+++ b/lib/Treex/Block/Sample/Trees.pm
@@ -226,7 +226,7 @@ sub precompute_alignment {
     foreach my $document (@$documents_rf) {
         foreach my $bundle ($document->get_bundles) {
             foreach my $node ($bundle->get_tree($self->language, 'a', $self->selector)->get_descendants) {
-                my ($nodes, $types) = $node->get_aligned_nodes();
+                my ($nodes, $types) = $node->get_directed_aligned_nodes();
                 foreach my $i (0 .. $#$nodes) {
                     if ($$types[$i] =~ /int/) {
                         $self->_alignment->{$node} = $$nodes[$i];

--- a/lib/Treex/Block/T2T/CopyFunctorsFromAlignment.pm
+++ b/lib/Treex/Block/T2T/CopyFunctorsFromAlignment.pm
@@ -6,7 +6,7 @@ extends 'Treex::Core::Block';
 
 sub process_tnode {
     my ( $self, $tnode ) = @_;
-    my ($aligned) = $tnode->get_aligned_nodes();
+    my ($aligned) = $tnode->get_directed_aligned_nodes();
 
     if ($aligned) {
         foreach my $source ( @{$aligned} ) {

--- a/lib/Treex/Block/T2T/CopyValencyFramesFromAlignment.pm
+++ b/lib/Treex/Block/T2T/CopyValencyFramesFromAlignment.pm
@@ -6,7 +6,7 @@ extends 'Treex::Core::Block';
 
 sub process_tnode {
     my ( $self, $tnode ) = @_;
-    my ($aligned) = $tnode->get_aligned_nodes();
+    my ($aligned) = $tnode->get_directed_aligned_nodes();
 
     if ($aligned) {
         foreach my $source ( @{$aligned} ) {

--- a/lib/Treex/Block/T2T/ProjectTreeThroughAlignment.pm
+++ b/lib/Treex/Block/T2T/ProjectTreeThroughAlignment.pm
@@ -26,7 +26,7 @@ sub process_bundle {
 
     # sort counterparts for each node from 'int' through 'gdfa' to 'right'
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( ( 0 .. $#$nodes ) ) {
             if ( $$types[$i] =~ /int/ && !defined $linked_to{ $$nodes[$i] } ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];
@@ -35,7 +35,7 @@ sub process_bundle {
         }
     }
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( ( 0 .. $#$nodes ) ) {
             if ( $$types[$i] =~ /gdfa/ && $$types[$i] =~ /right/ && $$types[$i] !~ /int/ && !defined $linked_to{ $$nodes[$i] } ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];
@@ -44,7 +44,7 @@ sub process_bundle {
         }
     }
     foreach my $node ( $source_root->get_descendants( { ordered => 1 } ) ) {
-        my ( $nodes, $types ) = $node->get_aligned_nodes();
+        my ( $nodes, $types ) = $node->get_directed_aligned_nodes();
         foreach my $i ( ( 0 .. $#$nodes ) ) {
             if ( $$types[$i] =~ /right/ && $$types[$i] !~ /gdfa/ && !defined $linked_to{ $$nodes[$i] } ) {
                 push @{ $counterparts[ $node->ord ] }, $$nodes[$i];

--- a/lib/Treex/Block/Treelets/ExtractVW.pm
+++ b/lib/Treex/Block/Treelets/ExtractVW.pm
@@ -48,7 +48,7 @@ sub process_start {
 
 sub process_tnode {
     my ( $self, $cs_tnode ) = @_;
-    my ($en_tnodes_rf, $ali_types_rf) = $cs_tnode->get_aligned_nodes();
+    my ($en_tnodes_rf, $ali_types_rf) = $cs_tnode->get_directed_aligned_nodes();
     for my $i (0 .. $#{$en_tnodes_rf}) {
         my $types = $ali_types_rf->[$i];
         if ($types =~ /int|tali/){

--- a/lib/Treex/Block/Treelets/ExtractVW2.pm
+++ b/lib/Treex/Block/Treelets/ExtractVW2.pm
@@ -48,7 +48,7 @@ sub process_start {
 
 sub process_tnode {
     my ( $self, $cs_tnode ) = @_;
-    my ($en_tnodes_rf, $ali_types_rf) = $cs_tnode->get_aligned_nodes();
+    my ($en_tnodes_rf, $ali_types_rf) = $cs_tnode->get_directed_aligned_nodes();
     for my $i (0 .. $#{$en_tnodes_rf}) {
         my $types = $ali_types_rf->[$i];
         if ($types =~ /int|tali/){

--- a/lib/Treex/Block/W2A/AnalysisWithAlignedTrees.pm
+++ b/lib/Treex/Block/W2A/AnalysisWithAlignedTrees.pm
@@ -61,7 +61,7 @@ sub _get_alignment_hash {
         }
     } else {
 
-        # Node->get_aligned_nodes() will be used directly
+        # Node->get_directed_aligned_nodes() will be used directly
         $alignment_hash = undef;
     }
 
@@ -70,14 +70,14 @@ sub _get_alignment_hash {
 
 # get the first node aligned to $node
 # with alignment of type set in $self->alignment_type
-# directly using $node->get_aligned_nodes()
+# directly using $node->get_directed_aligned_nodes()
 # (or return undef)
 sub _get_aligned_node {
     my ( $self, $node ) = @_;
 
     my $aligned_node = undef;
 
-    my ( $aligned_nodes, $types ) = $node->get_aligned_nodes();
+    my ( $aligned_nodes, $types ) = $node->get_directed_aligned_nodes();
     if ($aligned_nodes) {
 
         # try to find an aligned node with the right type of alignment

--- a/lib/Treex/Block/W2A/CS/FixPrepositionalCase.pm
+++ b/lib/Treex/Block/W2A/CS/FixPrepositionalCase.pm
@@ -135,9 +135,9 @@ sub _get_possible_cases {
 #sub _log_application {
 #    my ( $caption, $case, $word, $prep ) = @_;
 #
-#    my ($gold_word) = $word->get_aligned_nodes();
+#    my ($gold_word) = $word->get_directed_aligned_nodes();
 #    $gold_word = $gold_word->[0];
-#    my ($gold_prep) = $prep->get_aligned_nodes();
+#    my ($gold_prep) = $prep->get_directed_aligned_nodes();
 #    $gold_prep = $gold_prep->[0];
 #
 #    log_warn( join( "\t", ( $caption, $case, $word->tag, $gold_word->tag, $prep->tag, $gold_prep->tag, _log_sent( [ $word, $prep ] ) ) ) );

--- a/lib/Treex/Block/Write/Alignments.pm
+++ b/lib/Treex/Block/Write/Alignments.pm
@@ -34,7 +34,7 @@ sub process_zone {
     }
     else {
     	foreach my $sn (@source_nodes) {
-    		my @trg_nodes = grep {$_->is_aligned_to($sn, {rel_types => ['^'.$self->alignment_type.'$']})} $sn->get_referencing_nodes('alignment', $self->language, $self->selector);
+    		my @trg_nodes = grep {$_->is_directed_aligned_to($sn, {rel_types => ['^'.$self->alignment_type.'$']})} $sn->get_referencing_nodes('alignment', $self->language, $self->selector);
     		if (@trg_nodes) {
     			map{push @alignments, ($sn->ord-1) . '-' . ($_->ord-1) }@trg_nodes;
     		}

--- a/lib/Treex/Block/Write/Alignments.pm
+++ b/lib/Treex/Block/Write/Alignments.pm
@@ -34,7 +34,7 @@ sub process_zone {
     }
     else {
     	foreach my $sn (@source_nodes) {
-    		my @trg_nodes = grep {$_->is_aligned_to($sn, '^' . $self->alignment_type . '$')} $sn->get_referencing_nodes('alignment', $self->language, $self->selector);
+    		my @trg_nodes = grep {$_->is_aligned_to($sn, {rel_types => ['^'.$self->alignment_type.'$']})} $sn->get_referencing_nodes('alignment', $self->language, $self->selector);
     		if (@trg_nodes) {
     			map{push @alignments, ($sn->ord-1) . '-' . ($_->ord-1) }@trg_nodes;
     		}

--- a/lib/Treex/Block/Write/AmrAlignedCrossLang.pm
+++ b/lib/Treex/Block/Write/AmrAlignedCrossLang.pm
@@ -23,7 +23,7 @@ override '_get_aligned_anode' => sub {
     my $src_tnode = $tnode->src_tnode();
     return undef if !$src_tnode;
     
-    my ($ali_tnode) = $src_tnode->get_aligned_nodes();
+    my ($ali_tnode) = $src_tnode->get_directed_aligned_nodes();
     return undef if !$ali_tnode;
     $ali_tnode = $ali_tnode->[0];
     return $ali_tnode->get_lex_anode();
@@ -35,7 +35,7 @@ sub _get_aligned_ttree {
 
     return if !$src_ttree;
     my ($first_aligned) = first { defined $_ } map {
-        my ($ali_nodes) = $_->get_aligned_nodes();
+        my ($ali_nodes) = $_->get_directed_aligned_nodes();
         $ali_nodes ? @$ali_nodes : undef
     } $src_ttree->get_descendants();
     return undef if (!$first_aligned);

--- a/lib/Treex/Block/Write/AttributeParameterized.pm
+++ b/lib/Treex/Block/Write/AttributeParameterized.pm
@@ -357,9 +357,9 @@ sub _get_referenced_nodes {
                 }
             }
 
-            # get alignment going in both directions, using Treex::Tool::Align::Utils 
+            # get alignment going in both directions 
             else {
-                my ( $aligned_nodes, $aligned_nodes_types ) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node);
+                my ( $aligned_nodes, $aligned_nodes_types ) = $node->get_undirected_aligned_nodes();
                 if ($aligned_nodes) {
                     $self->_cache->{$ref}->{$node} = $aligned_nodes;
                 }

--- a/lib/Treex/Block/Write/AttributeParameterized.pm
+++ b/lib/Treex/Block/Write/AttributeParameterized.pm
@@ -4,7 +4,6 @@ use Moose::Role;
 use Moose::Util::TypeConstraints;
 use Treex::Core::Log;
 use Readonly;
-use Treex::Tool::Align::Utils;
 
 #
 # DATA

--- a/lib/Treex/Block/Write/AttributeParameterized.pm
+++ b/lib/Treex/Block/Write/AttributeParameterized.pm
@@ -4,6 +4,7 @@ use Moose::Role;
 use Moose::Util::TypeConstraints;
 use Treex::Core::Log;
 use Readonly;
+use Treex::Tool::Align::Utils;
 
 #
 # DATA
@@ -356,9 +357,9 @@ sub _get_referenced_nodes {
                 }
             }
 
-            # get alignment from $node->get_aligned_nodes()
+            # get alignment going in both directions, using Treex::Tool::Align::Utils 
             else {
-                my ( $aligned_nodes, $aligned_nodes_types ) = $node->get_aligned_nodes();
+                my ( $aligned_nodes, $aligned_nodes_types ) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node);
                 if ($aligned_nodes) {
                     $self->_cache->{$ref}->{$node} = $aligned_nodes;
                 }

--- a/lib/Treex/Block/Write/AttributeSentencesAligned.pm
+++ b/lib/Treex/Block/Write/AttributeSentencesAligned.pm
@@ -39,7 +39,7 @@ sub _process_tree() {
         $alignment_hash = {};
         my $aligned_root = $tree->get_bundle->get_tree( $self->alignment_language, $self->layer, $self->alignment_selector );
         foreach my $aligned_node ( $aligned_root->get_descendants ) {
-            my ( $nodes, $types ) = $aligned_node->get_aligned_nodes();
+            my ( $nodes, $types ) = $aligned_node->get_directed_aligned_nodes();
 	    if ($nodes) {
 		for (my $i = 0; $i < @{$nodes}; $i++) {
 		    my $node = $nodes->[$i];
@@ -58,7 +58,7 @@ sub _process_tree() {
         }
     }
 
-    # else: Node->get_aligned_nodes() will be used directly
+    # else: Node->get_directed_aligned_nodes() will be used directly
 
     # nodes of a sentence, each node consisting of several attributes
     print { $self->_file_handle } join $self->separator,
@@ -143,7 +143,7 @@ Default value of 1 means that the alignment information is stored in the nodes
 of C<alignment_language> and a reverse mapping is to be computed.
 Value of 0 means that alignment info is stored in the nodes of C<language>
 and nothing has to be precomputed:
-L<Treex::Core::Node/get_aligned_nodes> can be used directly.
+L<Treex::Core::Node/get_directed_aligned_nodes> can be used directly.
 
 =item C<attributes>
 

--- a/lib/Treex/Block/Write/Factored.pm
+++ b/lib/Treex/Block/Write/Factored.pm
@@ -667,7 +667,7 @@ sub process_bundle {
             my @alignments = ();
             foreach my $node1 ( sort { $a->get_attr('ord') <=> $b->get_attr('ord') } $tree1->get_descendants ) {
                 my $ord1    = $node1->get_attr('ord') - 1;
-                my ($nodes2, $types) = $node1->get_aligned_nodes();
+                my ($nodes2, $types) = $node1->get_directed_aligned_nodes();
                 next if ! defined $nodes2;
                 for(my $i=0; $i<scalar(@$nodes2); $i++) {
 #                 foreach my $node2 (keys %$counterparts_and_type) {

--- a/lib/Treex/Block/Write/LayerAttributes/AlignedFormWithoutPrefix.pm
+++ b/lib/Treex/Block/Write/LayerAttributes/AlignedFormWithoutPrefix.pm
@@ -9,7 +9,7 @@ has '+return_values_names' => ( default => sub { [''] } );
 sub modify_single {
 
     my ( $self, $anode ) = @_;
-    my ( $aligned_nodes ) = $anode->get_aligned_nodes();
+    my ( $aligned_nodes ) = $anode->get_directed_aligned_nodes();
     return '' if (!$aligned_nodes); # TODO return form of current node?
     
     my $aligned_node = shift @$aligned_nodes;

--- a/lib/Treex/Block/Write/LayerAttributes/BracketedVerbform.pm
+++ b/lib/Treex/Block/Write/LayerAttributes/BracketedVerbform.pm
@@ -16,7 +16,7 @@ sub modify_single {
     return '' if ( ( $tnode->gram_sempos || '' ) ne 'v' );
 
     if ( $self->use_aligned_golden ) {
-        my ($aligned) = $tnode->get_aligned_nodes();
+        my ($aligned) = $tnode->get_directed_aligned_nodes();
         $aligned = first { ( $_->gram_sempos || '' ) eq 'v' } @{$aligned};
         if ($aligned) {
             $tnode = $aligned;

--- a/lib/Treex/Block/Write/PCEDTAlignment.pm
+++ b/lib/Treex/Block/Write/PCEDTAlignment.pm
@@ -10,7 +10,7 @@ has '+extension' => ( default => '.align' );
 
 sub process_tnode {
     my ( $self,     $tnode ) = @_;
-    my ( $cs_nodes, $types ) = $tnode->get_aligned_nodes();
+    my ( $cs_nodes, $types ) = $tnode->get_directed_aligned_nodes();
     return if !$$cs_nodes[0];
     my $cs_tnode = $$cs_nodes[0];
     return if !$tnode->get_lex_anode;

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -1,0 +1,282 @@
+package Treex::Core::Node::Aligned;
+
+use Moose::Role;
+
+# with Moose >= 2.00, this must be present also in roles
+use MooseX::SemiAffordanceAccessor;
+use Treex::Core::Common;
+
+my $DEFAULT_FILTER = { 
+    directed => 1, 
+};
+
+sub get_aligned_nodes {
+    my ($self, $filter) = @_;
+
+    $filter //= { %{$self->default_filter} };
+    
+    # retrieve aligned nodes and its types outcoming links
+    
+    my ($aligned_to, $aligned_to_types) = $self->_get_direct_aligned_nodes();
+    #log_info "ALITO: " . Dumper($aligned_to_types);
+    #log_info "ALITOIDS: " . (join ",", map {$_->id} @$aligned_to);
+    my @aligned = $aligned_to ? @$aligned_to : ();
+    my @aligned_types = $aligned_to_types ? @$aligned_to_types : ();
+    
+    # retrieve aligned nodes and its types outcoming links
+    
+    my $directed = delete $filter->{directed};
+    if (!$directed) {
+        my @aligned_from = sort {$a->id cmp $b->id} $self->get_referencing_nodes('alignment');
+        my %seen_ids = ();
+        my @aligned_from_types = map {get_alignment_types($_, $self)} grep {!$seen_ids{$_->id}++} @aligned_from;
+        #log_info "ALIFROM: " . Dumper(\@aligned_from_types);
+        #log_info "ALIFROMIDS: " . (join ",", map {$_->id} @aligned_from);
+        push @aligned, @aligned_from;
+        push @aligned_types, @aligned_from_types;
+    }
+
+    # filter the retrieved nodes and links
+
+    my ($final_nodes, $final_types) = (\@aligned, \@aligned_types);
+    if (%$filter) {
+        ($final_nodes, $final_types) = _edge_filter_out($final_nodes, $final_types, $filter);
+        ($final_nodes, $final_types) = _node_filter_out($final_nodes, $final_types, $filter);
+    }
+  
+    log_debug "[Tool::Align::Utils::get_aligned_nodes_by_filter]\tfiltered: " . (join " ", @$final_types), 1;
+    return ($final_nodes, $final_types);
+}
+
+sub _node_filter_out {
+    my ($nodes, $types, $filter) = @_;
+    my $lang = $filter->{language};
+    my $sel = $filter->{selector};
+
+    my @idx = grep {
+        (!defined $lang || ($lang eq $nodes->[$_]->language)) &&
+        (!defined $sel || ($sel eq $nodes->[$_]->selector))
+    } 0 .. $#$nodes;
+
+    return ([@$nodes[@idx]], [@$types[@idx]]);
+}
+
+sub _value_of_type {
+    my ($type, $type_list) = @_;
+    my $i = 0;
+    foreach my $type_re (@$type_list) {
+        if ($type_re =~ /^!(.*)/) {
+            return undef if ($type =~ /^$1$/);
+        }
+        else {
+            return $i if ($type =~ /^$type_re$/);
+        }
+        $i++;
+    }
+    return undef;
+}
+
+sub _edge_filter_out {
+    my ($nodes, $types, $filter) = @_;
+    my $rel_types = $filter->{rel_types};
+    return ($nodes, $types) if (!defined $rel_types);
+    
+    #log_info 'ALITYPES: ' . Dumper($types);
+    my @values = map {_value_of_type($_, $rel_types)} @$types;
+    #log_info 'ALITYPES: ' . Dumper(\@values);
+    my @idx = grep { defined $values[$_] } 0 .. $#$nodes;
+    @idx = sort {$values[$a] <=> $values[$b]} @idx;
+
+    return ([@$nodes[@idx]], [@$types[@idx]]);
+}
+
+#sub get_aligned_nodes {
+sub _get_direct_aligned_nodes {
+    my ($self) = @_;
+    my $links_rf = $self->get_attr('alignment');
+    if ($links_rf) {
+        my $document = $self->get_document;
+        my @nodes    = map { $document->get_node_by_id( $_->{'counterpart.rf'} ) } @$links_rf;
+        my @types    = map { $_->{'type'} } @$links_rf;
+        return ( \@nodes, \@types );
+    }
+    return ( undef, undef );
+}
+
+#==============================================
+
+sub get_aligned_nodes_by_tree {
+    my ($self, $lang, $selector) = @_;
+    my @nodes = ();
+    my @types = ();
+    my $links_rf = $self->get_attr('alignment');
+    if ($links_rf) {
+        my $document = $self->get_document;
+        foreach my $l_rf (@{$links_rf}) {
+            if ($l_rf->{'counterpart.rf'} =~ /^(a|t)_tree-$lang(_$selector)?-.+$/) {
+                my $n = $document->get_node_by_id( $l_rf->{'counterpart.rf'} );
+                my $t = $l_rf->{'type'};
+                push @nodes, $n;
+                push @types, $t;
+            }
+        }
+        return ( \@nodes, \@types ) if     scalar(@nodes) > 0 ;    
+    }
+    return ( undef, undef );
+}
+
+sub get_aligned_nodes_of_type {
+    my ( $self, $type_regex, $lang, $selector ) = @_;
+    my @nodes;
+    my ( $n_rf, $t_rf );
+    if ((defined $lang) && (defined $selector)) {
+        ( $n_rf, $t_rf ) = $self->get_aligned_nodes_by_tree($lang, $selector);
+    }
+    else {
+        ( $n_rf, $t_rf ) = $self->get_aligned_nodes();    
+    }    
+    return if !$n_rf;
+    my $iterator = List::MoreUtils::each_arrayref( $n_rf, $t_rf );
+    while ( my ( $node, $type ) = $iterator->() ) {
+        if ( $type =~ /$type_regex/ ) {
+            push @nodes, $node;
+        }
+    }
+    return @nodes;
+}
+
+sub is_aligned_to {
+    my ( $self, $node, $type ) = @_;
+    log_fatal 'Incorrect number of parameters' if @_ != 3;
+    return ((any { $_ eq $node } $self->get_aligned_nodes_of_type( $type )) ? 1 : 0);
+}
+
+sub delete_aligned_node {
+    my ( $self, $node, $type ) = @_;
+    my $links_rf = $self->get_attr('alignment');
+    my @links    = ();
+    if ($links_rf) {
+        @links = grep {
+            $_->{'counterpart.rf'} ne $node->id
+                || ( defined($type) && defined( $_->{'type'} ) && $_->{'type'} ne $type )
+            }
+            @$links_rf;
+    }
+    $self->set_attr( 'alignment', \@links );
+    return;
+}
+
+sub add_aligned_node {
+    my ( $self, $node, $type ) = @_;
+    my $links_rf = $self->get_attr('alignment');
+    my %new_link = ( 'counterpart.rf' => $node->id, 'type' => $type // ''); #/ so we have no undefs
+    push( @$links_rf, \%new_link );
+    $self->set_attr( 'alignment', $links_rf );
+    return;
+}
+
+# remove invalid alignment links (leading to unindexed nodes)
+sub update_aligned_nodes {
+    my ($self)   = @_;
+    my $doc      = $self->get_document();
+    my $links_rf = $self->get_attr('alignment');
+    my @new_links;
+
+    foreach my $link ( @{$links_rf} ) {
+        push @new_links, $link if ( $doc->id_is_indexed( $link->{'counterpart.rf'} ) );
+    }
+    $self->set_attr( 'alignment', \@new_links );
+    return;
+}
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Treex::Core::Node::Aligned
+
+=head1 DESCRIPTION
+
+Moose role with methods to access alignment.
+
+=head1 METHODS
+
+=over
+
+=item ($ali_nodes, $ali_types) = $node->get_aligned_nodes($filter)
+
+This is the main getter method. It returns all nodes aligned to a specified node C<$node>,
+and types of these alignment links as two list references -- C<$ali_nodes>, and C<$ali_types>,
+respectively.
+
+By the optional parameter C<$filter>, one may specify a filter to be applied to the nodes
+and links. The filter is a hash reference, with the following possible keys:
+ 
+C<language> - the language of the aligned nodes (e.g. C<en>)
+C<selector> - the selector of the aligned nodes (e.g. C<src>)
+C<directed> - return only the links originating from the C<$node> (possible values: C<0> and C<1>)
+C<rel_types> - filter the alignment types. The value of this parameter must be a reference to
+a list of regular expression strings. The expressions starting with the C<!> sign represent negative
+filters. The actual link type is compared to these regexps one after another, skipping the rest
+if the type matches a current regexp. If the type matches no regexps in the list, it is filtered out.
+Therefore, negative rules should be at the beginning of the list, followed by at least one positive
+rule. For instance, C<['a','b']> returns only links of type C<a> or C<b>. On the other hand, 
+C<['!a','!b','.*']> returns everything except for C<a> and C<b>. The filter C<['!ab.*','a.*']>
+accepts only the types starting with C<a>, except for those starting with C<ab>.
+
+If no filter is specified, a default filter C<DEFAULT_FILTER> is used.
+
+Both returned list references -- C<$ali_nodes> and C<$ali_types>, are always defined. If the
+C<$node> has no alignment link that satisfies the filter constraints, a reference to an empty
+list is returned.
+
+
+=item $node->add_aligned_node($target, $type)
+
+Aligns $target node to $node. The prior existence of the link is not checked.
+
+=item my ($nodes_rf, $types_rf) = $node->get_aligned_nodes()
+
+Returns an array containing two array references. The first array contains the nodes aligned to this node, the second array contains types of the links.
+
+=item my @nodes = $node->get_aligned_nodes_of_type($regex_constraint_on_type)
+
+Returns a list of nodes aligned to the $node by the specified alignment type.
+
+=item $node->delete_aligned_node($target, $type)
+
+All alignments of the $target to $node are deleted, if their types equal $type.
+
+=item my $is_aligned = $node->is_aligned_to($target, $regex_constraint_on_type)
+
+Returns 1 if the nodes are aligned, 0 otherwise.
+
+=item $node->update_aligned_nodes()
+
+Removes all alignment links leading to nodes which have been deleted.
+
+=back
+
+=head1 CONSTANTS
+
+=over
+
+=item DEFAULT_FILTER
+
+A default filter is used, if no filter is specified for the methods that support it.
+By default: { directed => 1 }
+
+=back 
+
+=head1 AUTHOR
+
+Martin Popel <popel@ufal.mff.cuni.cz>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright © 2011 by Institute of Formal and Applied Linguistics, Charles University in Prague
+
+This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -13,7 +13,10 @@ use constant DEFAULT_FILTER => (
 sub get_aligned_nodes {
     my ($self, $filter) = @_;
 
-    $filter //= { DEFAULT_FILTER };
+    $filter //= {};
+    $filter = { map {
+        $filter->{$_} // DEFAULT_FILTER{$_} 
+    } keys DEFAULT_FILTER };
     
     # retrieve aligned nodes and its types outcoming links
     
@@ -119,13 +122,14 @@ sub get_aligned_nodes_of_type {
     return @$ali_nodes;
 }
 
+sub is_aligned_to {
+    my ($node1, $node2, $filter) = @_;
+    my ($nodes, $types) = $node1->get_aligned_nodes($filter);
+    return any {$_ == $node2} @$nodes;
+}
+
 #==============================================
 
-sub is_aligned_to {
-    my ( $self, $node, $type ) = @_;
-    log_fatal 'Incorrect number of parameters' if @_ != 3;
-    return ((any { $_ eq $node } $self->get_aligned_nodes_of_type( $type )) ? 1 : 0);
-}
 
 sub delete_aligned_node {
     my ( $self, $node, $type ) = @_;
@@ -193,7 +197,8 @@ and links. The filter is a hash reference, with the following possible keys:
  
 C<language> - the language of the aligned nodes (e.g. C<en>)
 C<selector> - the selector of the aligned nodes (e.g. C<src>)
-C<directed> - return only the links originating from the C<$node> (possible values: C<0> and C<1>)
+C<directed> - return only the links originating from the C<$node> (possible values: C<0> and C<1>,
+by default equals to C<1>)
 C<rel_types> - filter the alignment types. The value of this parameter must be a reference to
 a list of regular expression strings. The expressions starting with the C<!> sign represent negative
 filters. The actual link type is compared to these regexps one after another, skipping the rest

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -51,7 +51,7 @@ sub get_aligned_nodes {
         ($final_nodes, $final_types) = _node_filter_out($final_nodes, $final_types, $filter);
     }
   
-    log_debug "[Tool::Align::Utils::get_aligned_nodes_by_filter]\tfiltered: " . (join " ", @$final_types), 1;
+    log_debug "[Core::Node::Aligned::get_aligned_nodes]\tfiltered: " . (join " ", @$final_types), 1;
     return ($final_nodes, $final_types);
 }
 

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -166,7 +166,7 @@ sub delete_aligned_nodes_by_filter {
     my ($nodes, $types) = $node->get_aligned_nodes($filter);
     for (my $i = 0; $i < @$nodes; $i++) {
         log_debug "[Tool::Align::Utils::remove_aligned_nodes_by_filter]\tremoving: " . $types->[$i] . " " . $nodes->[$i]->id, 1;
-        if ($node->is_aligned_to($nodes->[$i], {directed => 1, rel_types => ['^'.$types->[$i].'$']})) {
+        if ($node->is_directed_aligned_to($nodes->[$i], {rel_types => ['^'.$types->[$i].'$']})) {
             $node->delete_aligned_node($nodes->[$i], $types->[$i]);
         }
         else {

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -6,13 +6,13 @@ use Moose::Role;
 use MooseX::SemiAffordanceAccessor;
 use Treex::Core::Common;
 
-sub _fill_default_filter_values {
+sub _set_directed_as_default {
     my ($filter) = @_;
     
     my $new_filter = $filter // {};
     if (!defined $new_filter->{directed}) {
-        log_warn "You called \$node->get_aligned_nodes(\$filter) without determining the \"directed\" parameter in the \$filter.
-            For the time being, it returns links only in the specified direction, but this will be changed soon."
+        log_warn "You called \$node->get_aligned_nodes(\$filter) without determining the \"directed\" parameter in the \$filter. "
+            . "For the time being, it returns links only in the specified direction, but this will be changed soon.";
         $new_filter->{directed} = 1;
     }
     return $new_filter;

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -132,13 +132,26 @@ sub get_aligned_nodes_of_type {
         log_warn "Note that a alignment type regex starting with ! has a special meaning.";
     }
 
-    my ($ali_nodes) = $self->get_aligned_nodes({ 
-        directed => 1, 
+    my ($ali_nodes) = $self->get_directed_aligned_nodes({ 
         language => $lang,
         selector => $selector,
         rel_types => [ $type_regex ],
     });
     return @$ali_nodes;
+}
+
+sub is_undirected_aligned_to {
+    my ($node1, $node2, $filter) = @_;
+    $filter //= {};
+    $filter->{directed} = 0;
+    return $node1->is_aligned_to($node2, $filter);
+}
+
+sub is_directed_aligned_to {
+    my ($node1, $node2, $filter) = @_;
+    $filter //= {};
+    $filter->{directed} = 1;
+    return $node1->is_aligned_to($node2, $filter);
 }
 
 sub is_aligned_to {

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -10,14 +10,24 @@ use constant DEFAULT_FILTER => (
     directed => 1, 
 );
 
+sub _fill_default_filter_values {
+    my ($filter) = @_;
+    
+    my $new_filter = $filter // {};
+    my %default_filter = DEFAULT_FILTER;
+
+    foreach my $key (keys %default_filter) {
+        if (!defined $filter->{$key}) {
+            $new_filter->{$key} = $default_filter{$key};
+        }
+    }
+    return $new_filter;
+}
+
 sub get_aligned_nodes {
     my ($self, $filter) = @_;
 
-    $filter //= {};
-    $filter = { map {
-        $filter->{$_} // DEFAULT_FILTER{$_} 
-    } keys DEFAULT_FILTER };
-    
+    $filter = _fill_default_filter_values($filter); 
     # retrieve aligned nodes and its types outcoming links
     
     my ($aligned_to, $aligned_to_types) = $self->_get_direct_aligned_nodes();

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -27,6 +27,7 @@ sub get_undirected_aligned_nodes {
 }
 
 sub get_directed_aligned_nodes {
+    my ($self, $filter) = @_;
     $filter //= {};
     $filter->{directed} = 1;
 

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -165,7 +165,7 @@ sub delete_aligned_nodes_by_filter {
 
     my ($nodes, $types) = $node->get_aligned_nodes($filter);
     for (my $i = 0; $i < @$nodes; $i++) {
-        log_debug "[Tool::Align::Utils::remove_aligned_nodes_by_filter]\tremoving: " . $types->[$i] . " " . $nodes->[$i]->id, 1;
+        log_debug "[Core::Node::Aligned::delete_aligned_nodes_by_filter]\tremoving: " . $types->[$i] . " " . $nodes->[$i]->id, 1;
         if ($node->is_directed_aligned_to($nodes->[$i], {rel_types => ['^'.$types->[$i].'$']})) {
             $node->delete_aligned_node($nodes->[$i], $types->[$i]);
         }
@@ -272,7 +272,7 @@ specified by the filter C<$filter> (see more in the C<get_aligned_nodes> functio
 
 All alignments of the $target to $node are deleted, if their types equal $type.
 
-=item $node->remove_aligned_nodes_by_filter($filter)
+=item $node->delete_aligned_nodes_by_filter($filter)
 
 This deletes the alignment links pointing from/to the node C<$node>. Only the links satisfying
 the C<$filter> constraints are removed.

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -6,14 +6,14 @@ use Moose::Role;
 use MooseX::SemiAffordanceAccessor;
 use Treex::Core::Common;
 
-my $DEFAULT_FILTER = { 
+use constant DEFAULT_FILTER => ( 
     directed => 1, 
-};
+);
 
 sub get_aligned_nodes {
     my ($self, $filter) = @_;
 
-    $filter //= { %{$self->default_filter} };
+    $filter //= { DEFAULT_FILTER };
     
     # retrieve aligned nodes and its types outcoming links
     
@@ -120,27 +120,6 @@ sub get_aligned_nodes_of_type {
 }
 
 #==============================================
-
-sub get_aligned_nodes_by_tree {
-    my ($self, $lang, $selector) = @_;
-    my @nodes = ();
-    my @types = ();
-    my $links_rf = $self->get_attr('alignment');
-    if ($links_rf) {
-        my $document = $self->get_document;
-        foreach my $l_rf (@{$links_rf}) {
-            if ($l_rf->{'counterpart.rf'} =~ /^(a|t)_tree-$lang(_$selector)?-.+$/) {
-                my $n = $document->get_node_by_id( $l_rf->{'counterpart.rf'} );
-                my $t = $l_rf->{'type'};
-                push @nodes, $n;
-                push @types, $t;
-            }
-        }
-        return ( \@nodes, \@types ) if     scalar(@nodes) > 0 ;    
-    }
-    return ( undef, undef );
-}
-
 
 sub is_aligned_to {
     my ( $self, $node, $type ) = @_;
@@ -264,7 +243,7 @@ Removes all alignment links leading to nodes which have been deleted.
 =item DEFAULT_FILTER
 
 A default filter is used, if no filter is specified for the methods that support it.
-By default: { directed => 1 }
+By default: ( directed => 1 )
 
 =back 
 

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -18,22 +18,6 @@ sub _set_directed_as_default {
     return $new_filter;
 }
 
-sub get_undirected_aligned_nodes {
-    my ($self, $filter) = @_;
-    $filter //= {};
-    $filter->{directed} = 0;
-
-    return $self->get_aligned_nodes($filter);
-}
-
-sub get_directed_aligned_nodes {
-    my ($self, $filter) = @_;
-    $filter //= {};
-    $filter->{directed} = 1;
-
-    return $self->get_aligned_nodes($filter);
-}
-
 sub get_aligned_nodes {
     my ($self, $filter) = @_;
 
@@ -69,6 +53,22 @@ sub get_aligned_nodes {
   
     log_debug "[Tool::Align::Utils::get_aligned_nodes_by_filter]\tfiltered: " . (join " ", @$final_types), 1;
     return ($final_nodes, $final_types);
+}
+
+sub get_undirected_aligned_nodes {
+    my ($self, $filter) = @_;
+    $filter //= {};
+    $filter->{directed} = 0;
+
+    return $self->get_aligned_nodes($filter);
+}
+
+sub get_directed_aligned_nodes {
+    my ($self, $filter) = @_;
+    $filter //= {};
+    $filter->{directed} = 1;
+
+    return $self->get_aligned_nodes($filter);
 }
 
 sub _node_filter_out {
@@ -140,6 +140,12 @@ sub get_aligned_nodes_of_type {
     return @$ali_nodes;
 }
 
+sub is_aligned_to {
+    my ($node1, $node2, $filter) = @_;
+    my ($nodes, $types) = $node1->get_aligned_nodes($filter);
+    return any {$_ == $node2} @$nodes;
+}
+
 sub is_undirected_aligned_to {
     my ($node1, $node2, $filter) = @_;
     $filter //= {};
@@ -152,12 +158,6 @@ sub is_directed_aligned_to {
     $filter //= {};
     $filter->{directed} = 1;
     return $node1->is_aligned_to($node2, $filter);
-}
-
-sub is_aligned_to {
-    my ($node1, $node2, $filter) = @_;
-    my ($nodes, $types) = $node1->get_aligned_nodes($filter);
-    return any {$_ == $node2} @$nodes;
 }
 
 sub delete_aligned_nodes_by_filter {

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -11,6 +11,8 @@ sub _fill_default_filter_values {
     
     my $new_filter = $filter // {};
     if (!defined $new_filter->{directed}) {
+        log_warn "You called \$node->get_aligned_nodes(\$filter) without determining the \"directed\" parameter in the \$filter.
+            For the time being, it returns links only in the specified direction, but this will be changed soon."
         $new_filter->{directed} = 1;
     }
     return $new_filter;

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -6,28 +6,35 @@ use Moose::Role;
 use MooseX::SemiAffordanceAccessor;
 use Treex::Core::Common;
 
-use constant DEFAULT_FILTER => ( 
-    directed => 1, 
-);
-
 sub _fill_default_filter_values {
     my ($filter) = @_;
     
     my $new_filter = $filter // {};
-    my %default_filter = DEFAULT_FILTER;
-
-    foreach my $key (keys %default_filter) {
-        if (!defined $filter->{$key}) {
-            $new_filter->{$key} = $default_filter{$key};
-        }
+    if (!defined $new_filter->{directed}) {
+        $new_filter->{directed} = 1;
     }
     return $new_filter;
+}
+
+sub get_undirected_aligned_nodes {
+    my ($self, $filter) = @_;
+    $filter //= {};
+    $filter->{directed} = 0;
+
+    return $self->get_aligned_nodes($filter);
+}
+
+sub get_directed_aligned_nodes {
+    $filter //= {};
+    $filter->{directed} = 1;
+
+    return $self->get_aligned_nodes($filter);
 }
 
 sub get_aligned_nodes {
     my ($self, $filter) = @_;
 
-    $filter = _fill_default_filter_values($filter); 
+    $filter = _set_directed_as_default($filter); 
     # retrieve aligned nodes and its types outcoming links
     
     my ($aligned_to, $aligned_to_types) = $self->_get_direct_aligned_nodes();
@@ -229,7 +236,8 @@ rule. For instance, C<['^a$','^b$']> returns only links of type C<a> or C<b>. On
 C<['!^a$','!^b$','.*']> returns everything except for C<a> and C<b>. The filter C<['!^ab.*','^a.*']>
 accepts only the types starting with C<a>, except for those starting with C<ab>.
 
-If no filter is specified, a default filter C<DEFAULT_FILTER> is used.
+For the time being, if the parameter C<directed> in the C<filter> is not specified,
+C<directed = 0> is the default.
 
 Both returned list references -- C<$ali_nodes> and C<$ali_types>, are always defined. If the
 C<$node> has no alignment link that satisfies the filter constraints, a reference to an empty
@@ -252,7 +260,8 @@ All alignments of the $target to $node are deleted, if their types equal $type.
 
 This deletes the alignment links pointing from/to the node C<$node>. Only the links satisfying
 the C<$filter> constraints are removed.
-If no filter specified, the C<DEFAULT_FILTER> is used.
+For the time being, if the parameter C<directed> in the C<filter> is not specified, 
+C<directed = 0> is the default.
 
 =item $node->add_aligned_node($target, $type)
 
@@ -264,23 +273,12 @@ Removes all alignment links leading to nodes which have been deleted.
 
 =back
 
-=head1 CONSTANTS
-
-=over
-
-=item DEFAULT_FILTER
-
-A default filter is used, if no filter is specified for the methods that support it.
-By default: ( directed => 1 )
-
-=back 
-
 =head1 AUTHOR
 
-Martin Popel <popel@ufal.mff.cuni.cz>
+Michal Novák <mnovak@ufal.mff.cuni.cz>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright © 2011 by Institute of Formal and Applied Linguistics, Charles University in Prague
+Copyright © 2015 by Institute of Formal and Applied Linguistics, Charles University in Prague
 
 This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Core/Node/Aligned.pm
+++ b/lib/Treex/Core/Node/Aligned.pm
@@ -252,12 +252,25 @@ rule. For instance, C<['^a$','^b$']> returns only links of type C<a> or C<b>. On
 C<['!^a$','!^b$','.*']> returns everything except for C<a> and C<b>. The filter C<['!^ab.*','^a.*']>
 accepts only the types starting with C<a>, except for those starting with C<ab>.
 
-For the time being, if the parameter C<directed> in the C<filter> is not specified,
-C<directed = 0> is the default.
+For the time being, C<directed = 1> is the default if it is not specified in the filter. However,
+this will probably change soon, so you had better use C<get_directed_aligned_nodes> for this purpose,
+or specify the C<directed> parameter, explicitly.
 
 Both returned list references -- C<$ali_nodes> and C<$ali_types>, are always defined. If the
 C<$node> has no alignment link that satisfies the filter constraints, a reference to an empty
 list is returned.
+
+=item ($ali_nodes, $ali_types) = $node->get_undirected_aligned_nodes($filter)
+
+Return counterparts of the links in both the specified and opposite direction.
+It calls C<get_aligned_nodes> with C<directed> equal to 0.
+
+=item ($ali_nodes, $ali_types) = $node->get_directed_aligned_nodes($filter)
+
+Return only counterparts of the links in the specified direction.
+Calls C<get_aligned_nodes> with C<directed> equal to 1.
+With undefined C<filter>, it corresponds to the original version of the
+C<get_aligned_nodes> method.
 
 =item my @nodes = $node->get_aligned_nodes_of_type($regex_constraint_on_type)
 
@@ -267,6 +280,17 @@ Returns a list of nodes aligned to the $node by the specified alignment type.
 
 An indicator function of whether the nodes C<$node1> and C<$node2> are aligned under the conditions
 specified by the filter C<$filter> (see more in the C<get_aligned_nodes> function description).
+For the time being, C<directed = 1> is the default if it is not specified in the filter. However,
+this will probably change soon, so you had better use C<is_directed_aligned_to> for this purpose,
+or specify the C<directed> parameter, explicitly.
+
+=item my $is_aligned = $node1->is_undirected_aligned_to($node2, $filter)
+
+The same as C<is_aligned_to>, accepting links in both the specified and the opposite direction.
+
+=item my $is_aligned = $node1->is_directed_aligned_to($node2, $filter)
+
+The same as C<is_aligned_to>, accepting links only in the specified direction.
 
 =item $node->delete_aligned_node($target, $type)
 
@@ -276,8 +300,7 @@ All alignments of the $target to $node are deleted, if their types equal $type.
 
 This deletes the alignment links pointing from/to the node C<$node>. Only the links satisfying
 the C<$filter> constraints are removed.
-For the time being, if the parameter C<directed> in the C<filter> is not specified, 
-C<directed = 0> is the default.
+If the parameter C<directed> in the C<filter> is not specified, C<directed = 0> is the default.
 
 =item $node->add_aligned_node($target, $type)
 

--- a/lib/Treex/Core/Node/t/alignment.t
+++ b/lib/Treex/Core/Node/t/alignment.t
@@ -27,9 +27,23 @@ cmp_ok(@$nodes_rf, '==', 1, 'orientation');
 cmp_ok(@$types_rf, '==', 1, 'orientation');
 is($nodes_rf->[0], $en_node, 'correct node');
 is($types_rf->[0], 'alignment', 'correct type');
+($nodes_rf, $types_rf) = $cs_node->get_undirected_aligned_nodes;
+cmp_ok(@$nodes_rf, '==', 1, 'orientation');
+cmp_ok(@$types_rf, '==', 1, 'orientation');
+is($nodes_rf->[0], $en_node, 'correct node');
+is($types_rf->[0], 'alignment', 'correct type');
+($nodes_rf, $types_rf) = $en_node->get_undirected_aligned_nodes;
+cmp_ok(@$nodes_rf, '==', 1, 'opposite link');
+cmp_ok(@$types_rf, '==', 1, 'opposite link');
+is($nodes_rf->[0], $cs_node, 'correct node');
+is($types_rf->[0], 'alignment', 'correct type');
+($nodes_rf, $types_rf) = $en_node->get_aligned_nodes;
+cmp_ok(@$nodes_rf, '==', 0, 'directed = 1 by default');
 
 cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'is aligned');
 cmp_ok($en_node->is_directed_aligned_to($cs_node, {rel_types => ['.']}), '==', 0, 'is not aligned');
+cmp_ok($cs_node->is_undirected_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'is aligned');
+cmp_ok($en_node->is_undirected_aligned_to($cs_node, {rel_types => ['.']}), '==', 1, 'is aligned');
 
 is(($cs_node->get_aligned_nodes_of_type('gn'))[0], $en_node, 'get_aligned_nodes_of_type');
 
@@ -45,5 +59,34 @@ $cs_node->add_aligned_node($en_node, 'relation');
 $cs_node->delete_aligned_node($en_node, 'alignment');
 cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['alignment']}), '==', 0, 'deleted');
 cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['relation']}), '==', 1, 'not deleted');
+
+$en_node->add_aligned_node($cs_node, 'noitaler');
+($nodes_rf, $types_rf) = $cs_node->get_undirected_aligned_nodes();
+cmp_ok(@$nodes_rf, '==', 2, 'both directions');
+($nodes_rf, $types_rf) = $en_node->get_undirected_aligned_nodes();
+cmp_ok(@$nodes_rf, '==', 2, 'both directions');
+
+($nodes_rf, $types_rf) = $en_node->get_undirected_aligned_nodes({ language => 'xx' });
+cmp_ok(@$nodes_rf, '==', 0, 'no node in language xx');
+($nodes_rf, $types_rf) = $en_node->get_undirected_aligned_nodes({ language => 'en' });
+cmp_ok(@$nodes_rf, '==', 0, 'no link to the same language');
+($nodes_rf, $types_rf) = $en_node->get_undirected_aligned_nodes({ language => 'cs' });
+cmp_ok(@$nodes_rf, '==', 2, 'only links to the other language');
+($nodes_rf, $types_rf) = $en_node->get_directed_aligned_nodes({ language => 'cs' });
+cmp_ok(@$nodes_rf, '==', 1, 'only directed links to the other language');
+
+my $en_node2 = $en_root->create_child;
+my $cs_node2 = $cs_root->create_child;
+$en_node2->add_aligned_node($cs_node, 'noitaler_2');
+$cs_node2->add_aligned_node($en_node2, 'relation_2');
+($nodes_rf, $types_rf) = $en_node2->get_undirected_aligned_nodes({ rel_types => ['.*_2'] });
+cmp_ok(@$nodes_rf, '==', 2, 'nodes linked via noitaler_2, relation_2');
+is_deeply([sort @$types_rf], ['noitaler_2', 'relation_2'], 'nodes linked via noitaler_2, relation_2');
+($nodes_rf, $types_rf) = $en_node2->get_undirected_aligned_nodes({ rel_types => ['!^rel.*', '.*_2'] });
+cmp_ok(@$nodes_rf, '==', 1, 'nodes linked via noitaler_2');
+is_deeply($types_rf, ['noitaler_2'], 'nodes linked via noitaler_2');
+($nodes_rf, $types_rf) = $cs_node->get_undirected_aligned_nodes({ rel_types => ['!.*_2', '.*'] });
+cmp_ok(@$nodes_rf, '==', 2, 'nodes linked via noitaler, relation');
+is_deeply([sort @$types_rf], ['noitaler', 'relation'], 'nodes linked via noitaler, relation');
 
 done_testing;

--- a/lib/Treex/Core/Node/t/alignment.t
+++ b/lib/Treex/Core/Node/t/alignment.t
@@ -14,8 +14,8 @@ my $cs_root = $cs_zone->create_ttree;
 my $en_node = $en_root->create_child;
 my $cs_node = $cs_root->create_child;
 
-cmp_ok($en_node->get_aligned_nodes // 0, '==', 0, 'no alignment');
-cmp_ok($cs_node->get_aligned_nodes // 0, '==', 0, 'no alignment');
+is_deeply([$en_node->get_aligned_nodes], [[], []], 'no alignment');
+is_deeply([$cs_node->get_aligned_nodes], [[], []], 'no alignment');
 
 $cs_node->add_aligned_node($en_node, 'alignment');
 

--- a/lib/Treex/Core/Node/t/alignment.t
+++ b/lib/Treex/Core/Node/t/alignment.t
@@ -28,8 +28,8 @@ cmp_ok(@$types_rf, '==', 1, 'orientation');
 is($nodes_rf->[0], $en_node, 'correct node');
 is($types_rf->[0], 'alignment', 'correct type');
 
-cmp_ok($cs_node->is_aligned_to($en_node, '.'), '==', 1, 'is aligned');
-cmp_ok($en_node->is_aligned_to($cs_node, '.'), '==', 0, 'is not aligned');
+cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'is aligned');
+cmp_ok($en_node->is_aligned_to($cs_node, {rel_types => ['.']}), '==', 0, 'is not aligned');
 
 is(($cs_node->get_aligned_nodes_of_type('gn'))[0], $en_node, 'get_aligned_nodes_of_type');
 
@@ -39,11 +39,11 @@ cmp_ok(@$nodes_rf, '==', 2, 'duplicate');
 cmp_ok(@$types_rf, '==', 2, 'duplicate');
 
 $cs_node->delete_aligned_node($en_node, 'nonsense');
-cmp_ok($cs_node->is_aligned_to($en_node, '.'), '==', 1, 'not deleted');
+cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'not deleted');
 
 $cs_node->add_aligned_node($en_node, 'relation');
 $cs_node->delete_aligned_node($en_node, 'alignment');
-cmp_ok($cs_node->is_aligned_to($en_node, 'alignment'), '==', 0, 'deleted');
-cmp_ok($cs_node->is_aligned_to($en_node, 'relation'), '==', 1, 'not deleted');
+cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['alignment']}), '==', 0, 'deleted');
+cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['relation']}), '==', 1, 'not deleted');
 
 done_testing;

--- a/lib/Treex/Core/Node/t/alignment.t
+++ b/lib/Treex/Core/Node/t/alignment.t
@@ -14,36 +14,36 @@ my $cs_root = $cs_zone->create_ttree;
 my $en_node = $en_root->create_child;
 my $cs_node = $cs_root->create_child;
 
-is_deeply([$en_node->get_aligned_nodes], [[], []], 'no alignment');
-is_deeply([$cs_node->get_aligned_nodes], [[], []], 'no alignment');
+is_deeply([$en_node->get_directed_aligned_nodes], [[], []], 'no alignment');
+is_deeply([$cs_node->get_directed_aligned_nodes], [[], []], 'no alignment');
 
 $cs_node->add_aligned_node($en_node, 'alignment');
 
-my ($nodes_rf, $types_rf) = $en_node->get_aligned_nodes;
+my ($nodes_rf, $types_rf) = $en_node->get_directed_aligned_nodes;
 cmp_ok(@$nodes_rf, '==', 0, 'orientation');
 cmp_ok(@$types_rf, '==', 0, 'orientation');
-($nodes_rf, $types_rf) = $cs_node->get_aligned_nodes;
+($nodes_rf, $types_rf) = $cs_node->get_directed_aligned_nodes;
 cmp_ok(@$nodes_rf, '==', 1, 'orientation');
 cmp_ok(@$types_rf, '==', 1, 'orientation');
 is($nodes_rf->[0], $en_node, 'correct node');
 is($types_rf->[0], 'alignment', 'correct type');
 
-cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'is aligned');
-cmp_ok($en_node->is_aligned_to($cs_node, {rel_types => ['.']}), '==', 0, 'is not aligned');
+cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'is aligned');
+cmp_ok($en_node->is_directed_aligned_to($cs_node, {rel_types => ['.']}), '==', 0, 'is not aligned');
 
 is(($cs_node->get_aligned_nodes_of_type('gn'))[0], $en_node, 'get_aligned_nodes_of_type');
 
 $cs_node->add_aligned_node($en_node, 'alignment');
-($nodes_rf, $types_rf) = $cs_node->get_aligned_nodes;
+($nodes_rf, $types_rf) = $cs_node->get_directed_aligned_nodes;
 cmp_ok(@$nodes_rf, '==', 2, 'duplicate');
 cmp_ok(@$types_rf, '==', 2, 'duplicate');
 
 $cs_node->delete_aligned_node($en_node, 'nonsense');
-cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'not deleted');
+cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['.']}), '==', 1, 'not deleted');
 
 $cs_node->add_aligned_node($en_node, 'relation');
 $cs_node->delete_aligned_node($en_node, 'alignment');
-cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['alignment']}), '==', 0, 'deleted');
-cmp_ok($cs_node->is_aligned_to($en_node, {rel_types => ['relation']}), '==', 1, 'not deleted');
+cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['alignment']}), '==', 0, 'deleted');
+cmp_ok($cs_node->is_directed_aligned_to($en_node, {rel_types => ['relation']}), '==', 1, 'not deleted');
 
 done_testing;

--- a/lib/Treex/Core/TredView.pm
+++ b/lib/Treex/Core/TredView.pm
@@ -381,7 +381,7 @@ sub node_release_hook {
         and
         $roots[0] != $roots[1] and $zones[0] != $zones[1]) {
 
-        if ($node->is_aligned_to($target, {rel_types => ['alignment']})) {
+        if ($node->is_directed_aligned_to($target, {rel_types => ['alignment']})) {
             $node->delete_aligned_node($target, 'alignment');
         } else {
             $node->add_aligned_node($target, 'alignment');

--- a/lib/Treex/Core/TredView.pm
+++ b/lib/Treex/Core/TredView.pm
@@ -381,7 +381,7 @@ sub node_release_hook {
         and
         $roots[0] != $roots[1] and $zones[0] != $zones[1]) {
 
-        if ($node->is_aligned_to($target, 'alignment')) {
+        if ($node->is_aligned_to($target, {rel_types => ['alignment']})) {
             $node->delete_aligned_node($target, 'alignment');
         } else {
             $node->add_aligned_node($target, 'alignment');

--- a/lib/Treex/Tool/Align/Features.pm
+++ b/lib/Treex/Tool/Align/Features.pm
@@ -3,7 +3,6 @@ package Treex::Tool::Align::Features;
 use Moose;
 use Treex::Core::Common;
 
-use Treex::Tool::Align::Utils;
 use Graph;
 use Treex::Tool::Lexicon::UniversalTagset;
 use Treex::Tool::Coreference::NodeFilter::PersPron;

--- a/lib/Treex/Tool/Align/Features.pm
+++ b/lib/Treex/Tool/Align/Features.pm
@@ -170,7 +170,10 @@ sub _get_sent_graph {
     foreach my $node (@nodes) {
         $g->set_edge_attribute($node->id, $node->get_parent->id, "type", "parent");
         $g->set_edge_attribute($node->get_parent->id, $node->id, "type", "child");
-        my ($ali_nodes, $ali_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node, { directed => 1, rel_types => $GIZA_ORIG_RULES_FILTER });
+        my ($ali_nodes, $ali_types) = $node->get_directed_aligned_nodes({
+            directed => 1,
+            rel_types => $GIZA_ORIG_RULES_FILTER
+        });
         foreach my $ali (@$ali_nodes) {
             $g->add_weighted_edge($node->id, $ali->id, 100);
             $g->add_weighted_edge($ali->id, $node->id, 100);
@@ -204,12 +207,19 @@ sub _get_subtree_aligns {
 
     my @ali_phrase_nodes = ();
     if ($type eq 'clause_head') {
-        my ($an, $at) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($par, {selector => $par->selector, rel_types => $GIZA_ORIG_RULES_FILTER });
+        my ($an, $at) = $par->get_undirected_aligned_nodes({
+            selector => $par->selector,
+            rel_types => $GIZA_ORIG_RULES_FILTER
+        });
         @ali_phrase_nodes = @$an;
     }
     else {
         @ali_phrase_nodes = map {
-            my ($an, $at) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($_, {selector => $_->selector, rel_types => $GIZA_ORIG_RULES_FILTER }); @$an
+            my ($an, $at) = $_->get_undirected_aligned_nodes({
+                selector => $_->selector,
+                rel_types => $GIZA_ORIG_RULES_FILTER,
+            });
+            @$an
         } $par->get_descendants();
     }
 

--- a/lib/Treex/Tool/Align/Features.pm
+++ b/lib/Treex/Tool/Align/Features.pm
@@ -84,13 +84,13 @@ sub _add_align_features {
 
     # all alignmnets excpt for the gold one projected from "ref"
     # TODO: do not project gold annotation to "src" => clearer solution
-    my $nodes_aligned = Treex::Tool::Align::Utils::are_aligned($node1, $node2, { rel_types => $GIZA_ORIG_RULES_FILTER });
+    my $nodes_aligned = $node1->is_undirected_aligned_to($node2, { rel_types => $GIZA_ORIG_RULES_FILTER });
     $feats->{giza_aligned} = $nodes_aligned ? 1 : 0;
 
 
     my ($par1) = $node1->get_eparents({or_topological => 1});
     my ($par2) = $node2->get_eparents({or_topological => 1});
-    my $par_aligned = Treex::Tool::Align::Utils::are_aligned($par1, $par2, { rel_types => $GIZA_ORIG_RULES_FILTER });
+    my $par_aligned = $par1->is_undirected_aligned_to($par2, { rel_types => $GIZA_ORIG_RULES_FILTER });
     $feats->{par_aligned} = $par_aligned ? 1 : 0;
 
     $feats->{subtree_aligned_all} = $self->subtree_alignment($node1, $node2, 'all') ? 1 : 0;

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -13,21 +13,6 @@ my %SIEVES_HASH = (
     siblings => \&access_via_siblings,
 );
 
-sub remove_aligned_nodes_by_filter {
-    my ($node, $filter) = @_;
-
-    my ($nodes, $types) = get_aligned_nodes_by_filter($node, $filter);
-    for (my $i = 0; $i < @$nodes; $i++) {
-        log_debug "[Tool::Align::Utils::remove_aligned_nodes_by_filter]\tremoving: " . $types->[$i] . " " . $nodes->[$i]->id, 1;
-        if ($node->is_aligned_to($nodes->[$i], {directed => 1, rel_types => ['^'.$types->[$i].'$']})) {
-            $node->delete_aligned_node($nodes->[$i], $types->[$i]);
-        }
-        else {
-            $nodes->[$i]->delete_aligned_node($node, $types->[$i]);
-        }
-    }
-}
-
 sub add_aligned_node {
     my ($node1, $node2, $type) = @_;
     #log_info "ALIGN ADD: " . $node2->id;
@@ -180,16 +165,6 @@ of alignment links in the particular document.
 =head1 FUNCTIONS
 
 =over
-
-=item $bool = are_aligned($node1, $node2, $filter)
-
-An indicator function of whether the nodes C<$node1> and C<$node2> are aligned under the conditions
-specified by the filter C<$filter> (see more in the C<get_aligned_nodes_by_filter> function description).
-
-=item remove_aligned_nodes_by_filter($node, $filter)
-
-This deletes the alignment links pointing from/to the node C<$node>. Only the links satisfying
-the C<$filter> constraints are removed.
 
 =back
 

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -65,7 +65,7 @@ sub aligned_transitively {
 
     my $filter;
     foreach my $filter (@$filters) {
-        @level_aligned = map {my ($n, $t) = get_aligned_nodes_by_filter($_, $filter); @$n;} @level_aligned;
+        @level_aligned = map {my ($n, $t) = $_->get_undirected_aligned_nodes($filter); @$n;} @level_aligned;
     }
     return @level_aligned;
 }
@@ -149,12 +149,6 @@ Treex::Tool::Align::Utils
 
  use Treex::Tool::Align::Utils;
 
- my ($ali_nodes, $ali_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter(
-    $tnode,
-    { language => 'en', selector => 'src', rel_types => ['!gold','!supervised','.*'] }
- );
- 
- 
 =head1 DESCRIPTION
 
 Even though word-alignment is considered to be non-directional, Treex natively represents

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -20,41 +20,6 @@ sub are_aligned {
     return any {$_ == $node2} @$nodes;
 }
 
-sub get_aligned_nodes_by_filter {
-    my ($node, $filter) = @_;
-    
-    # retrieve aligned nodes and its types outcoming links
-    
-    my ($aligned_to, $aligned_to_types) = $node->get_aligned_nodes();
-    #log_info "ALITO: " . Dumper($aligned_to_types);
-    #log_info "ALITOIDS: " . (join ",", map {$_->id} @$aligned_to);
-    my @aligned = $aligned_to ? @$aligned_to : ();
-    my @aligned_types = $aligned_to_types ? @$aligned_to_types : ();
-    
-    # retrieve aligned nodes and its types outcoming links
-    
-    if (!$filter || !$filter->{directed}) {
-        my @aligned_from = sort {$a->id cmp $b->id} $node->get_referencing_nodes('alignment');
-        my %seen_ids = ();
-        my @aligned_from_types = map {get_alignment_types($_, $node)} grep {!$seen_ids{$_->id}++} @aligned_from;
-        #log_info "ALIFROM: " . Dumper(\@aligned_from_types);
-        #log_info "ALIFROMIDS: " . (join ",", map {$_->id} @aligned_from);
-        push @aligned, @aligned_from;
-        push @aligned_types, @aligned_from_types;
-    }
-
-    # filter the retrieved nodes and links
-
-    my ($final_nodes, $final_types) = (\@aligned, \@aligned_types);
-    if ($filter) {
-        ($final_nodes, $final_types) = _edge_filter_out($final_nodes, $final_types, $filter);
-        ($final_nodes, $final_types) = _node_filter_out($final_nodes, $final_types, $filter);
-    }
-  
-    log_debug "[Tool::Align::Utils::get_aligned_nodes_by_filter]\tfiltered: " . (join " ", @$final_types), 1;
-    return ($final_nodes, $final_types);
-}
-
 sub remove_aligned_nodes_by_filter {
     my ($node, $filter) = @_;
 
@@ -68,48 +33,6 @@ sub remove_aligned_nodes_by_filter {
             $nodes->[$i]->delete_aligned_node($node, $types->[$i]);
         }
     }
-}
-
-sub _node_filter_out {
-    my ($nodes, $types, $filter) = @_;
-    my $lang = $filter->{language};
-    my $sel = $filter->{selector};
-
-    my @idx = grep {
-        (!defined $lang || ($lang eq $nodes->[$_]->language)) &&
-        (!defined $sel || ($sel eq $nodes->[$_]->selector))
-    } 0 .. $#$nodes;
-
-    return ([@$nodes[@idx]], [@$types[@idx]]);
-}
-
-sub _value_of_type {
-    my ($type, $type_list) = @_;
-    my $i = 0;
-    foreach my $type_re (@$type_list) {
-        if ($type_re =~ /^!(.*)/) {
-            return undef if ($type =~ /^$1$/);
-        }
-        else {
-            return $i if ($type =~ /^$type_re$/);
-        }
-        $i++;
-    }
-    return undef;
-}
-
-sub _edge_filter_out {
-    my ($nodes, $types, $filter) = @_;
-    my $rel_types = $filter->{rel_types};
-    return ($nodes, $types) if (!defined $rel_types);
-    
-    #log_info 'ALITYPES: ' . Dumper($types);
-    my @values = map {_value_of_type($_, $rel_types)} @$types;
-    #log_info 'ALITYPES: ' . Dumper(\@values);
-    my @idx = grep { defined $values[$_] } 0 .. $#$nodes;
-    @idx = sort {$values[$a] <=> $values[$b]} @idx;
-
-    return ([@$nodes[@idx]], [@$types[@idx]]);
 }
 
 sub add_aligned_node {
@@ -139,7 +62,7 @@ sub get_alignment_types {
     my @all_types;
     my @types_idx;
     
-    my ($nodes, $types) = $from->get_aligned_nodes();
+    my ($nodes, $types) = $from->_get_direct_aligned_nodes();
     if (defined $nodes) {
         @types_idx = grep {$nodes->[$_] == $to} 0 .. scalar(@$nodes)-1;
     }
@@ -147,7 +70,7 @@ sub get_alignment_types {
     
     # try the opposite link
     if ($both_dir) {
-        ($nodes, $types) = $to->get_aligned_nodes();
+        ($nodes, $types) = $to->_get_direct_aligned_nodes();
         if (defined $nodes) {
             @types_idx = grep {$nodes->[$_] == $from} 0 .. scalar(@$nodes)-1;
         }
@@ -264,30 +187,6 @@ of alignment links in the particular document.
 =head1 FUNCTIONS
 
 =over
-
-=item ($ali_nodes, $ali_types) = get_aligned_nodes_by_filter($node, $filter)
-
-This is the main getter method. It returns all nodes aligned to a specified node C<$node>,
-and types of these alignment links as two list references -- C<$ali_nodes>, and C<$ali_types>,
-respectively. By the parameter C<$filter>, one may specify a filter to be applied to the nodes
-and links. The filter is a hash reference, with the following possible keys:
- 
-C<language> - the language of the aligned nodes (e.g. C<en>)
-C<selector> - the selector of the aligned nodes (e.g. C<src>)
-C<directed> - return only the links originating from the C<$node> (possible values: C<0> and C<1>)
-C<rel_types> - filter the alignment types. The value of this parameter must be a reference to
-a list of regular expression strings. The expressions starting with the C<!> sign represent negative
-filters. The actual link type is compared to these regexps one after another, skipping the rest
-if the type matches a current regexp. If the type matches no regexps in the list, it is filtered out.
-Therefore, negative rules should be at the beginning of the list, followed by at least one positive
-rule. For instance, C<['a','b']> returns only links of type C<a> or C<b>. On the other hand, 
-C<['!a','!b','.*']> returns everything except for C<a> and C<b>. The filter C<['!ab.*','a.*']>
-accepts only the types starting with C<a>, except for those starting with C<ab>.
-                
-
-Both returned list references -- C<$ali_nodes> and C<$ali_types>, are always defined. If the
-C<$node> has no alignment link that satisfies the filter constraints, a reference to an empty
-list is returned.
 
 =item $bool = are_aligned($node1, $node2, $filter)
 

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -24,7 +24,7 @@ sub add_aligned_node {
         $node1->add_aligned_node($node2, $type);
     }
 
-    #if ($node1->is_aligned_to($node2, {directed => 1, rel_types => ['^'.$old_type.'$']})) {
+    #if ($node1->is_directed_aligned_to($node2, {rel_types => ['^'.$old_type.'$']})) {
     #    $node1->delete_aligned_node($node2, $old_type);
     #    $node1->add_aligned_node($node2, "$old_type $type");
     #}

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -13,20 +13,13 @@ my %SIEVES_HASH = (
     siblings => \&access_via_siblings,
 );
 
-sub are_aligned {
-    my ($node1, $node2, $filter) = @_;
-
-    my ($nodes, $types) = get_aligned_nodes_by_filter($node1, $filter);
-    return any {$_ == $node2} @$nodes;
-}
-
 sub remove_aligned_nodes_by_filter {
     my ($node, $filter) = @_;
 
     my ($nodes, $types) = get_aligned_nodes_by_filter($node, $filter);
     for (my $i = 0; $i < @$nodes; $i++) {
         log_debug "[Tool::Align::Utils::remove_aligned_nodes_by_filter]\tremoving: " . $types->[$i] . " " . $nodes->[$i]->id, 1;
-        if ($node->is_aligned_to($nodes->[$i], $types->[$i])) {
+        if ($node->is_aligned_to($nodes->[$i], {directed => 1, rel_types => ['^'.$types->[$i].'$']})) {
             $node->delete_aligned_node($nodes->[$i], $types->[$i]);
         }
         else {
@@ -46,7 +39,7 @@ sub add_aligned_node {
         $node1->add_aligned_node($node2, $type);
     }
 
-    #if ($node1->is_aligned_to($node2, $old_type)) {
+    #if ($node1->is_aligned_to($node2, {directed => 1, rel_types => ['^'.$old_type.'$']})) {
     #    $node1->delete_aligned_node($node2, $old_type);
     #    $node1->add_aligned_node($node2, "$old_type $type");
     #}

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -108,12 +108,6 @@ sub access_via_siblings {
     return @aligned_sibs;
 }
 
-sub print_nodes {
-    my (@nodes) = @_;
-    my @addresses = map {$_->get_address} @nodes;
-    print STDERR Dumper(\@addresses);
-}
-
 1;
 
 __END__

--- a/lib/Treex/Tool/Align/Utils.pm
+++ b/lib/Treex/Tool/Align/Utils.pm
@@ -17,7 +17,8 @@ sub add_aligned_node {
     my ($node1, $node2, $type) = @_;
     #log_info "ALIGN ADD: " . $node2->id;
         
-    my @old_types = get_alignment_types($node1, $node2);
+    # TODO should not call a private method of a different class
+    my @old_types = $node1->_get_alignment_types($node2);
     my $type_defined = any {$_ eq $type} @old_types;
     if (!$type_defined) {
         #log_info "ADD_ALIGN: $type " . $node2->id;
@@ -32,30 +33,6 @@ sub add_aligned_node {
     #    $node2->delete_aligned_node($node1, $old_type);
     #    $node2->add_aligned_node($node1, "$old_type $type");
     #}
-}
-
-sub get_alignment_types {
-    my ($from, $to, $both_dir) = @_;
-
-    my @all_types;
-    my @types_idx;
-    
-    my ($nodes, $types) = $from->_get_direct_aligned_nodes();
-    if (defined $nodes) {
-        @types_idx = grep {$nodes->[$_] == $to} 0 .. scalar(@$nodes)-1;
-    }
-    push @all_types, @$types[@types_idx];
-    
-    # try the opposite link
-    if ($both_dir) {
-        ($nodes, $types) = $to->_get_direct_aligned_nodes();
-        if (defined $nodes) {
-            @types_idx = grep {$nodes->[$_] == $from} 0 .. scalar(@$nodes)-1;
-        }
-        push @all_types, @$types[@types_idx];
-    }
-    
-    return @all_types;
 }
 
 sub aligned_transitively {

--- a/lib/Treex/Tool/Coreference/Features/Aligned.pm
+++ b/lib/Treex/Tool/Coreference/Features/Aligned.pm
@@ -39,11 +39,11 @@ sub _build_unary_feats_cache {
 sub _binary_features {
     my ($self, $set_features, $anaph, $cand, $candord) = @_;
 
-    my ($ali_anaph_nodes, $ali_anaph_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($anaph, $self->_align_filter);
+    my ($ali_anaph_nodes, $ali_anaph_types) = $anaph->get_undirected_aligned_nodes($self->_align_filter);
 # TODO: features based on the errors returned
     return {} if (!@$ali_anaph_nodes);
     log_debug "[Tool::Coreference::Features::Aligned::_binary_features]\tanaphor ali_types: " . (join " ", @$ali_anaph_types), 1;
-    my ($ali_cand_nodes, $ali_cand_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($cand, $self->_align_filter);
+    my ($ali_cand_nodes, $ali_cand_types) = $cand->get_undirected_aligned_nodes($self->_align_filter);
 # TODO: features based on the errors returned
     return {} if (!@$ali_cand_nodes);
     log_debug "[Tool::Coreference::Features::Aligned::_binary_features]\tcand ali_types: " . (join " ", @$ali_cand_types), 1;
@@ -77,7 +77,7 @@ sub _binary_features {
 sub _unary_features {
     my ($self, $node, $type) = @_;
 
-    my ($ali_nodes, $ali_types) = Treex::Tool::Align::Utils::get_aligned_nodes_by_filter($node, $self->_align_filter);
+    my ($ali_nodes, $ali_types) = $node->get_undirected_aligned_nodes($self->_align_filter);
 # TODO: features based on the errors returned
     return {} if (!@$ali_nodes);
     log_debug "[Tool::Coreference::Features::Aligned::_unary_features]\tanaphor ali_types: " . (join " ", @$ali_types), 1;

--- a/lib/Treex/Tool/Coreference/Features/Aligned.pm
+++ b/lib/Treex/Tool/Coreference/Features/Aligned.pm
@@ -2,7 +2,6 @@ package Treex::Tool::Coreference::Features::Aligned;
 
 use Moose;
 use Treex::Core::Common;
-use Treex::Tool::Align::Utils;
 #use Cache::MemoryCache;
 
 with 'Treex::Tool::Coreference::CorefFeatures';


### PR DESCRIPTION
A new role `Core::Node::Aligned` for `Core::Node`, providing alignment accessors. It offers the original functions so far available in `Core::Node` as well as the additional functions from `Tool::Align::Utils` that access aligned nodes regardless the orientation of the links (undirected access). However, the two sources are not just stuck together in the target role. Functionality of some methods has been slightly modified. Namely:

##### `get_aligned_nodes`
* support for undirected access and filtering by language, selector and relation type
* never returns a couple of undefined values. If there are no counterparts, a pair of references to empty arrays are returned, for nodes and relation types, respectively
* if the method is called as it used to be called, i.e., with no parameters, it scans only the links in the specified direction, for the time being. It corresponds to the functionality of the previous version. However, since it is planned to be changed to undirected access, soon, the user is encouraged by a warning to use `get_directed_aligned_nodes` instead.

##### `get_directed_aligned_nodes`, `get_undirected_aligned_nodes`
* the version of `get_aligned_nodes` with directed and undirected access, respectively
* `get_directed_aligned_nodes` does the same job as the original `get_aligned_nodes` (except that it does not return undefs), so all uses of `get_aligned_nodes` in Treex have been changed to `get_directed_aligned_nodes`

##### `is_aligned_to`
* support for undirected access and filtering by language, selector and relation type
* if the method is called as it used to be called, i.e., with no parameters, it scans only the links in the specified direction, for the time being. It corresponds to the functionality of the previous version. However, since it is planned to be changed to undirected access, soon, the user is warn with the same warning as for the `get_aligned_nodes` method.

##### `is_directed_aligned_to`, `is_undirected_aligned_to`
* the version of `is_aligned_to` with directed and undirected access, respectively
* `is_directed_aligned_to` does the same job as the original `is_aligned_to`, so all uses of `is_aligned_to` in Treex have been changed to `is_directed_aligned_to`

There is one additional method `delete_aligned_nodes_by_filter`combining `get_aligned_nodes` and `delete_aligned_node`. In this case, undirected access is default, if not set differently by the filter.

[ closes #47 ]