### PR TITLE
treat any sentence that contains only whitespace as empty

### DIFF
--- a/lib/Treex/Block/Read/Sentences.pm
+++ b/lib/Treex/Block/Read/Sentences.pm
@@ -13,7 +13,7 @@ sub next_document {
 
     my $document = $self->new_document();
     foreach my $sentence ( split /\n/, $text ) {
-        next if ($sentence eq '' and $self->skip_empty);
+        next if ($sentence =~ /^\s*$/ and $self->skip_empty);
         my $bundle = $document->create_bundle();
         my $zone = $bundle->create_zone( $self->language, $self->selector );
         $zone->set_sentence($sentence);


### PR DESCRIPTION
For the purposes of Read::Sentences skip_empty=1, as a sentence that contains only whitespace is still considered to be empty by the tokenizer and it dies there.
This may change some behaviour somewhere, so I am submitting this as a pull request not to break anything.