### PR TITLE
Czech analysis merged to one file again

### DIFF
--- a/lib/Treex/Scen/Analysis/CS.pm
+++ b/lib/Treex/Scen/Analysis/CS.pm
@@ -1,20 +1,169 @@
 package Treex::Scen::Analysis::CS;
 use Moose;
 use Treex::Core::Common;
-with 'Treex::Core::RememberArgs';
+
+#
+# main parameters
+#
+
+has tokenizer => (
+    is => 'ro',
+    isa => enum( [qw(default whitespace none)] ),
+    default => 'default',
+);
+
+has tagger => (
+     is => 'ro',
+     isa => enum( [qw(MorphoDiTa Featurama Morce none)] ),
+     default => 'MorphoDiTa',
+);
+
+has ner => (
+     is => 'ro',
+     isa => enum( [qw(NameTag simple none)] ),
+     default => 'NameTag',
+     documentation => '',
+);
+
+has parser => (
+     is => 'ro',
+     isa => enum( [qw(MST none)] ),
+     default => 'MST',
+     documentation => 'Which dependency parser to use',
+);
+
+has tecto => (
+     is => 'ro',
+     isa => enum( [qw(default none)] ),
+     default => 'default',
+     documentation => 'Which tectogrammatical analysis to use',
+);
+
+
+#
+# parameters for detailed tuning of the analysis
+#
+
+has functors => (
+     is => 'ro',
+     isa => enum( [qw(MLProcess simple VW)] ),
+     default => 'MLProcess',
+);
+
+has valframes => (
+     is => 'ro',
+     isa => 'Bool',
+     default => 0,
+);
+
+has domain => (
+     is => 'ro',
+     isa => enum( [qw(general IT)] ),
+     default => 'general',
+     documentation => '',
+);
+
+has gazetteer => (
+     is => 'ro',
+     isa => 'Str',
+     default => '0',
+);
+
+# TODO gazetteers should work without any dependance on target language
+has trg_lang => (
+    is => 'ro',
+    isa => 'Str',
+);
+
+#
+# main method
+#
 
 sub get_scenario_string {
     my ($self) = @_;
-    my $params = $self->args_str;
+    my @blocks = ();
 
-    my $scen = join "\n",
-    "Scen::Analysis::CS::M $params",
-    "Scen::Analysis::CS::N $params",
-    "Scen::Analysis::CS::A $params",
-    "Scen::Analysis::CS::T $params",
-    ;
+    if ($self->tokenizer ne 'none'){
+        push @blocks,
+            $self->tokenizer eq 'whitespace' ? 'W2A::TokenizeOnWhitespace' : 'W2A::CS::Tokenize',
+            $self->gazetteer && defined $self->trg_lang ?
+                'W2A::GazeteerMatch trg_lang=' . $self->trg_lang . ' filter_id_prefixes="' . $self->gazetteer . '"' :
+                (),
+            ;
+    }
 
-    return $scen;
+    if ($self->tagger ne 'none'){
+        push @blocks,
+            $self->tagger eq 'MorphoDiTa' ? 'W2A::CS::TagMorphoDiTa lemmatize=1' : (),
+            $self->tagger eq 'Featurama'  ? 'W2A::CS::TagFeaturama lemmatize=1' : (),
+            $self->tagger eq 'Morce'      ? 'W2A::CS::TagMorce lemmatize=1' : (),
+            'W2A::CS::FixMorphoErrors',
+            'W2A::CS::FixGuessedLemmas',
+            ;
+    }
+
+    if ($self->ner ne 'none'){
+        push @blocks,
+            $self->ner eq 'NameTag' ? 'A2N::CS::NameTag' : (),
+            $self->ner eq 'simple' ? 'A2N::CS::SimpleRuleNER' : (),
+            $self->domain eq 'IT' ? 'A2N::CS::FixNERforIT' : (),
+            'A2N::CS::NormalizeNames',
+            ;
+    }
+
+    if ($self->parser ne 'none') {
+        push @blocks,
+            'W2A::CS::ParseMSTAdapted',
+            'W2A::CS::FixAtreeAfterMcD',
+            'W2A::CS::FixIsMember',
+            'W2A::CS::FixPrepositionalCase',
+            'W2A::CS::FixReflexiveTantum',
+            'W2A::CS::FixReflexivePronouns',
+            ;
+    }
+
+    if ($self->tecto ne 'none') {
+        push @blocks,
+            'A2T::CS::MarkEdgesToCollapse', ####expletives=0
+            'A2T::BuildTtree',
+            'A2T::RehangUnaryCoordConj',
+            'A2T::SetIsMember',
+            'A2T::CS::SetCoapFunctors',
+            'A2T::FixIsMember',
+            'A2T::MarkParentheses',
+            'A2T::MoveAuxFromCoordToMembers',
+            'A2T::CS::MarkClauseHeads',
+            'A2T::CS::MarkRelClauseHeads',
+            'A2T::CS::MarkRelClauseCoref',
+            #A2T::DeleteChildlessPunctuation We want quotes as t-nodes
+            $self->gazetteer ? 'A2T::ProjectGazeteerInfo' : (),
+            'A2T::CS::FixTlemmas',
+            'A2T::CS::FixNumerals',
+            'A2T::SetNodetype',
+            'A2T::CS::SetFormeme use_version=2 fix_prep=0',
+            'A2T::CS::SetDiathesis',
+            $self->functors eq 'MLProcess' ? 'A2T::CS::SetFunctors memory=2g' : (),
+            $self->functors eq 'VW' ? 'A2T::CS::SetFunctorsVW' : (),
+            $self->functors ne 'VW' ? 'A2T::CS::SetMissingFunctors': (),
+            'A2T::SetNodetype',
+            'A2T::FixAtomicNodes',
+            'A2T::CS::SetGrammatemes',
+            'A2T::SetSentmod',
+            $self->valframes ? 'A2T::CS::SetValencyFrameRefVW' : (),
+            'A2T::CS::MarkReflexivePassiveGen',
+            'A2T::CS::FixNonthirdPersSubj',
+            'A2T::CS::AddPersPron',
+            'T2T::SetClauseNumber',
+            'A2T::CS::MarkReflpronCoref',
+            'A2T::SetDocOrds',
+            'Coref::CS::SetMultiGender',
+            'A2T::CS::MarkTextPronCoref',
+            'Coref::RearrangeLinks retain_cataphora=1',
+            'Coref::DisambiguateGrammatemes',
+            ;
+    }
+
+    return join "\n", @blocks;
 }
 
 1;
@@ -32,7 +181,7 @@ Treex::Scen::Analysis::CS - Czech tectogrammatical analysis
 
  # From command line
  treex -Lcs Read::Sentences from=my.txt Scen::Analysis::CS Write::Treex to=my.treex.gz
- 
+
  treex --dump_scenario Scen::Analysis::CS
 
 =head1 DESCRIPTION
@@ -41,23 +190,63 @@ This scenario starts with tokenization, so sentence segmentation must be perform
 It covers: tokenization, tagging+lemmatization (MorphoDiTa), NER (NameTag),
 dependency parsing (MST) and tectogrammatical analysis.
 
-Sequentially invokes
-L<Scen::Analysis::CS::M>,
-L<Scen::Analysis::CS::N>,
-L<Scen::Analysis::CS::A>, and
-L<Scen::Analysis::CS::T>.
 
 =head1 PARAMETERS
 
-See
-L<Scen::Analysis::CS::M>,
-L<Scen::Analysis::CS::N>,
-L<Scen::Analysis::CS::A>, and
-L<Scen::Analysis::CS::T>.
+=item tagger
+
+Which PoS tagger to use: 
+C<tagger=MorphoDiTa> (default), or C<tagger=Featurama>, or C<tagger=Morce>,
+or C<tagger=none> (for pre-tagged text).
+
+=item ner
+
+Which Named Entity Recognizer to use:
+C<ner=NameTag> (default), or C<ner=simple>, or C<ner=none>.
+
+=item parser
+
+Which parser to use -- C<parser=MST> (default) or C<parser=none> (if parsing is 
+not required).
+
+=item tecto
+
+Which t-layer conversion to use -- C<tecto=default> or C<tecto=none> (if 
+tecto-analysis is not required).
+
+=item domain
+
+Domain of the input texts: C<domain=general> (default), or C<domain=IT>.
+
+=item functors
+
+Which analyzer of functors to use:
+C<functors=MLProcess> (default), or C<functors=simple>, or C<functors=VW>.
+
+=item gazetteer
+
+Use W2A::GazeteerMatch A2T::ProjectGazeteerInfo?
+C<gazetteer=0> (default), or C<gazetteer=all>,
+and other options -- see L<W2A::GazeteerMatch>.
+
+=item trg_lang
+
+Gazetteers are defined for language pairs. Both source and target languages must be specified.
+
+=item valframes
+
+Set valency frame references to valency dictionary?
+C<valframes=0> (default), or C<valframes=1>.
+
+=back
 
 =head1 AUTHORS
 
 Martin Popel <popel@ufal.mff.cuni.cz>
+
+Rudolf Rosa <rosa@ufal.mff.cuni.cz>
+
+Ondřej Dušek <odusek@ufal.mff.cuni.cz>
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/Treex/Scen/Analysis/CS/A.pm
+++ b/lib/Treex/Scen/Analysis/CS/A.pm
@@ -1,21 +1,11 @@
 package Treex::Scen::Analysis::CS::A;
 use Moose;
 use Treex::Core::Common;
-use utf8;
+with 'Treex::Core::RememberArgs';
 
 sub get_scenario_string {
     my ($self) = @_;
-
-    my $scen = join "\n",
-    'W2A::CS::ParseMSTAdapted',
-    'W2A::CS::FixAtreeAfterMcD',
-    'W2A::CS::FixIsMember',
-    'W2A::CS::FixPrepositionalCase',
-    'W2A::CS::FixReflexiveTantum',
-    'W2A::CS::FixReflexivePronouns',
-    ;
-
-    return $scen;
+    return 'Scen::Analysis::CS tokenizer=none tagger=none ner=none tecto=none ' . $self->args_str;
 }
 
 1;

--- a/lib/Treex/Scen/Analysis/CS/M.pm
+++ b/lib/Treex/Scen/Analysis/CS/M.pm
@@ -1,7 +1,7 @@
 package Treex::Scen::Analysis::CS::M;
 use Moose;
 use Treex::Core::Common;
-use utf8;
+with 'Treex::Core::RememberArgs';
 
 has tagger => (
      is => 'ro',
@@ -23,19 +23,7 @@ has trg_lang => (
 
 sub get_scenario_string {
     my ($self) = @_;
-
-    my $scen = join "\n",
-    'W2A::CS::Tokenize',
-    $self->gazetteer && defined $self->trg_lang ? 'W2A::GazeteerMatch trg_lang='.$self->trg_lang.' filter_id_prefixes="'.$self->gazetteer.'"' : (),
-    $self->tagger eq 'MorphoDiTa' ? 'W2A::CS::TagMorphoDiTa lemmatize=1' : (),
-    $self->tagger eq 'Featurama'  ? 'W2A::CS::TagFeaturama lemmatize=1' : (),
-    $self->tagger eq 'Morce'      ? 'W2A::CS::TagMorce lemmatize=1' : (),
-    'W2A::CS::FixMorphoErrors',
-
-    'W2A::CS::FixGuessedLemmas', ###############
-    ;
-
-    return $scen;
+    return 'Scen::Analysis::CS tokenizer=none ner=none parser=none tecto=none ' . $self->args_str;
 }
 
 1;

--- a/lib/Treex/Scen/Analysis/CS/N.pm
+++ b/lib/Treex/Scen/Analysis/CS/N.pm
@@ -1,7 +1,7 @@
 package Treex::Scen::Analysis::CS::N;
 use Moose;
 use Treex::Core::Common;
-use utf8;
+with 'Treex::Core::RememberArgs';
 
 has domain => (
      is => 'ro',
@@ -19,15 +19,7 @@ has ner => (
 
 sub get_scenario_string {
     my ($self) = @_;
-
-    my $scen = join "\n",
-    $self->ner eq 'NameTag' ? 'A2N::CS::NameTag' : (),
-    $self->ner eq 'simple' ? 'A2N::CS::SimpleRuleNER' : (),
-    $self->domain eq 'IT' ? 'A2N::CS::FixNERforIT' : (),
-    'A2N::CS::NormalizeNames',
-    ;
-
-    return $scen;
+    return 'Scen::Analysis::CS tokenizer=none tagger=none parser=none tecto=none ' . $self->args_str;
 }
 
 1;

--- a/lib/Treex/Scen/Analysis/CS/T.pm
+++ b/lib/Treex/Scen/Analysis/CS/T.pm
@@ -1,7 +1,7 @@
 package Treex::Scen::Analysis::CS::T;
 use Moose;
 use Treex::Core::Common;
-use utf8;
+with 'Treex::Core::RememberArgs';
 
 has functors => (
      is => 'ro',
@@ -23,47 +23,7 @@ has valframes => (
 
 sub get_scenario_string {
     my ($self) = @_;
-
-    my $scen = join "\n",
-    'A2T::CS::MarkEdgesToCollapse', ####expletives=0
-    'A2T::BuildTtree',
-    'A2T::RehangUnaryCoordConj',
-    'A2T::SetIsMember',
-    'A2T::CS::SetCoapFunctors',
-    'A2T::FixIsMember',
-    'A2T::MarkParentheses',
-    'A2T::MoveAuxFromCoordToMembers',
-    'A2T::CS::MarkClauseHeads',
-    'A2T::CS::MarkRelClauseHeads',
-    'A2T::CS::MarkRelClauseCoref',
-    #A2T::DeleteChildlessPunctuation We want quotes as t-nodes
-    $self->gazetteer ? 'A2T::ProjectGazeteerInfo' : (),
-    'A2T::CS::FixTlemmas',
-    'A2T::CS::FixNumerals',
-    'A2T::SetNodetype',
-    'A2T::CS::SetFormeme use_version=2 fix_prep=0',
-    'A2T::CS::SetDiathesis',
-    $self->functors eq 'MLProcess' ? 'A2T::CS::SetFunctors memory=2g' : (),
-    $self->functors eq 'VW' ? 'A2T::CS::SetFunctorsVW' : (),
-    $self->functors ne 'VW' ? 'A2T::CS::SetMissingFunctors': (),
-    'A2T::SetNodetype',
-    'A2T::FixAtomicNodes',
-    'A2T::CS::SetGrammatemes',
-    'A2T::SetSentmod',
-    $self->valframes ? 'A2T::CS::SetValencyFrameRefVW' : (),
-    'A2T::CS::MarkReflexivePassiveGen',
-    'A2T::CS::FixNonthirdPersSubj',
-    'A2T::CS::AddPersPron',
-    'T2T::SetClauseNumber',
-    'A2T::CS::MarkReflpronCoref',
-    'A2T::SetDocOrds',
-    'Coref::CS::SetMultiGender',
-    'A2T::CS::MarkTextPronCoref',
-    'Coref::RearrangeLinks retain_cataphora=1',
-    'Coref::DisambiguateGrammatemes',
-    ;
-
-    return $scen;
+    return 'Scen::Analysis::CS tokenizer=none tagger=none ner=none parser=none ' . $self->args_str;
 }
 
 1;


### PR DESCRIPTION
The structure now follows the English analysis (with parameters `tokenizer`, `tagger`, `ner`, `parser`, and `tecto` that may be set to `none` to disable the given part of the analysis).

The original Analysis::CS::[AMNT] modules now use the joint module with parameters.