### PR TITLE
Coreference aware of appositions

### DIFF
--- a/lib/Treex/Core/Node/EffectiveRelations.pm
+++ b/lib/Treex/Core/Node/EffectiveRelations.pm
@@ -261,20 +261,6 @@ sub is_echild_of {
     return any { $_ == $potential_echild } @echildren;
 }
 
-sub get_appos_expansion {
-    my ($self, $arg_ref ) = @_;
-    if ($self->is_coap_root && $self->functor eq "APPS") {
-        return ($self->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $self : ());
-    }
-    else {
-        my $par = $self->get_parent;
-        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
-            return ($par->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $par : ());
-        }
-    }
-    return $self;
-}
-
 1;
 
 __END__
@@ -451,25 +437,6 @@ For example "(A and B) or C":
 =item dive
 
 see L<get_echildren>
-
-=back
-
-=item $node->get_appos_expansion($arg_ref?)
-
-If the node is part of an apposition (no matter whether as a root
-or a member), return all the nodes that constitute the apposition.
-Only the apposition root may be excluded from the selection if the
-option C<with_appos_root> is off.
-The method is used to abstract from the technical implementation
-of appositions. So far, it is used by coreference accessors.
-
-OPTIONS
-
-=over
-
-=item with_appos_root
-
-Include the apposition root. Disabled by default.
 
 =back
 

--- a/lib/Treex/Core/Node/EffectiveRelations.pm
+++ b/lib/Treex/Core/Node/EffectiveRelations.pm
@@ -261,6 +261,20 @@ sub is_echild_of {
     return any { $_ == $potential_echild } @echildren;
 }
 
+sub get_appos_expansion {
+    my ($self, $arg_ref ) = @_;
+    if ($self->is_coap_root && $self->functor eq "APPS") {
+        return ($self->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $self : ());
+    }
+    else {
+        my $par = $self->get_parent;
+        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
+            return ($par->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $par : ());
+        }
+    }
+    return $self;
+}
+
 1;
 
 __END__
@@ -437,6 +451,25 @@ For example "(A and B) or C":
 =item dive
 
 see L<get_echildren>
+
+=back
+
+=item $node->get_appos_expansion($arg_ref?)
+
+If the node is part of an apposition (no matter whether as a root
+or a member), return all the nodes that constitute the apposition.
+Only the apposition root may be excluded from the selection if the
+option C<with_appos_root> is off.
+The method is used to abstract from the technical implementation
+of appositions. So far, it is used by coreference accessors.
+
+OPTIONS
+
+=over
+
+=item with_appos_root
+
+Include the apposition root. Disabled by default.
 
 =back
 

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -301,14 +301,22 @@ sub select_node_if_apps {
 
 sub _add_coref_nodes {
     my ($self, $type, @antes) = @_;
+    
+    # if called on a member of an apposition, call it on the apposition root
     my $anaph = select_node_if_apps($self);
     if ($anaph != $self) {
         return $anaph->_add_coref_nodes($type, @antes);
     }
+
+    # antes must be apposition roots if in apposition
     @antes = map {select_node_if_apps($_)} @antes;
+    
+    # avoid link repeating and self-reference
     my %seen;
-    @antes = grep {!$seen{$_->id}++} @antes;
-    return $self->_add_to_node_list( "coref_$type.rf", @antes );
+    @antes = grep {$_ != $self} grep {!$seen{$_->id}++} @antes;
+    return if (!@antes); 
+    
+    $self->_add_to_node_list( "coref_$type.rf", @antes );
 }
 
 sub add_coref_gram_nodes {

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -299,10 +299,10 @@ sub select_node_if_apps {
 }
 
 sub _add_coref_nodes {
-    my ($self, $type, @antes) = shift;
+    my ($self, $type, @antes) = @_;
     my $anaph = select_node_if_apps($self);
     if ($anaph != $self) {
-        return $anaph->add_coref_gram_nodes(@_);
+        return $anaph->_add_coref_nodes($type, @antes);
     }
     @antes = map {select_node_if_apps($_)} @antes;
     my %seen;

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -274,11 +274,12 @@ sub get_coref_chain {
 
     my %visited_nodes = ();
     my @nodes;
-    my @queue = ( $self->_get_node_list('coref_gram.rf'), $self->_get_node_list('coref_text.rf') );
+    my %sub_args = map {$_ => $arg_ref->{$_}} qw/appos_aware with_types/;
+    my @queue = $self->get_coref_nodes(\%sub_args);
     while ( my $node = shift @queue ) {
         $visited_nodes{$node} = 1;
         push @nodes, $node;
-        my @antes = ( $node->_get_node_list('coref_gram.rf'), $node->_get_node_list('coref_text.rf') );
+        my @antes = $node->get_coref_nodes(\%sub_args);
         foreach my $ante (@antes) {
             if ( !defined $visited_nodes{$ante} ) {
                 push @queue, $ante;

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -161,25 +161,25 @@ sub get_anodes {
 
 #------------ coreference and bridging nodes -------------------
 
-sub get_node_appos_expanded {
-    my ($node, $arg) = @_;
-    if ($node->is_coap_root && $node->functor eq "APPS") {
-        return ($node->get_coap_members, $arg->{with_appos_root} ? $node : ());
+sub get_appos_expansion {
+    my ($self, $arg) = @_;
+    if ($self->is_coap_root && $self->functor eq "APPS") {
+        return ($self->get_coap_members, $arg->{with_appos_root} ? $self : ());
     }
     else {
-        my $par = $node->get_parent;
-        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $node->is_member ) {
+        my $par = $self->get_parent;
+        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
             return ($par->get_coap_members, $arg->{with_appos_root} ? $par : ());
         }
     }
-    return $node;
+    return $self;
 }
 
 # types are not allowed for the time being
 sub _unfold_appos {
     my ( $self, $type ) = @_;
 
-    my @appos_nodes_not_self = grep {$_ != $self} get_node_appos_expanded($self, {with_appos_root => 1});
+    my @appos_nodes_not_self = grep {$_ != $self} $self->get_appos_expansion({with_appos_root => 1});
     
     my @member_antes = ();
     # type = { text, gram, all }
@@ -197,7 +197,7 @@ sub _unfold_appos {
 
 sub _replace_appos_antes {
     my (@antes) = @_;
-    my @new_antes = map {get_node_appos_expanded($_)} @antes;
+    my @new_antes = map {$_->get_appos_expansion({with_appos_root => 0})} @antes;
     my %seen = ();
     my @unique_antes = grep { !$seen{$_->id}++ } @new_antes;
     return @unique_antes; 

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -161,6 +161,20 @@ sub get_anodes {
 
 #------------ coreference and bridging nodes -------------------
 
+sub get_appos_expansion {
+    my ($self, $arg_ref ) = @_;
+    if ($self->is_coap_root && $self->functor eq "APPS") {
+        return ($self->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $self : ());
+    }
+    else {
+        my $par = $self->get_parent;
+        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
+            return ($par->get_coap_members({direct_only => 1}), $arg_ref->{with_appos_root} ? $par : ());
+        }
+    }
+    return $self;
+}
+
 # types are not allowed for the time being
 sub _unfold_appos {
     my ( $self, $type ) = @_;
@@ -539,6 +553,25 @@ The method returns references to two lists of the equal length: the referred nod
 
 Add bridging anaphora to C<$node> of type C<$type> (to C<bridging>).
 
+=item $node->get_appos_expansion($arg_ref?)
+
+If the node is part of an apposition (no matter whether as a root
+or a member), return all the nodes that constitute the apposition.
+Only the apposition root may be excluded from the selection if the
+option C<with_appos_root> is off.
+The method is used to abstract from the technical implementation
+of appositions. So far, it is used by coreference accessors.
+
+OPTIONS
+
+=over
+
+=item with_appos_root
+
+Include the apposition root. Disabled by default.
+
+=back
+
 =back
 
 =head2 Access to source language t-layer (in MT)
@@ -599,8 +632,10 @@ Martin Popel <popel@ufal.mff.cuni.cz>
 
 Ondřej Dušek <odusek@ufal.mff.cuni.cz>
 
+Michal Novák <mnovak@ufal.mff.cuni.cz>
+
 =head1 COPYRIGHT AND LICENSE
 
-Copyright © 2011-2012 by Institute of Formal and Applied Linguistics, Charles University in Prague
+Copyright © 2011-2016 by Institute of Formal and Applied Linguistics, Charles University in Prague
 
 This module is free software; you can redistribute it and/or modify it under the same terms as Perl itself.

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -164,12 +164,12 @@ sub get_anodes {
 sub get_appos_expansion {
     my ($self, $arg) = @_;
     if ($self->is_coap_root && $self->functor eq "APPS") {
-        return ($self->get_coap_members, $arg->{with_appos_root} ? $self : ());
+        return ($self->get_coap_members({direct_only => 1}), $arg->{with_appos_root} ? $self : ());
     }
     else {
         my $par = $self->get_parent;
         if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
-            return ($par->get_coap_members, $arg->{with_appos_root} ? $par : ());
+            return ($par->get_coap_members({direct_only => 1}), $arg->{with_appos_root} ? $par : ());
         }
     }
     return $self;

--- a/lib/Treex/Core/Node/T.pm
+++ b/lib/Treex/Core/Node/T.pm
@@ -161,20 +161,6 @@ sub get_anodes {
 
 #------------ coreference and bridging nodes -------------------
 
-sub get_appos_expansion {
-    my ($self, $arg) = @_;
-    if ($self->is_coap_root && $self->functor eq "APPS") {
-        return ($self->get_coap_members({direct_only => 1}), $arg->{with_appos_root} ? $self : ());
-    }
-    else {
-        my $par = $self->get_parent;
-        if (defined $par && !$par->is_root && $par->is_coap_root && $par->functor eq "APPS" && $self->is_member ) {
-            return ($par->get_coap_members({direct_only => 1}), $arg->{with_appos_root} ? $par : ());
-        }
-    }
-    return $self;
-}
-
 # types are not allowed for the time being
 sub _unfold_appos {
     my ( $self, $type ) = @_;

--- a/lib/Treex/Scen/Analysis/CS.pm
+++ b/lib/Treex/Scen/Analysis/CS.pm
@@ -158,7 +158,7 @@ sub get_scenario_string {
             'A2T::SetDocOrds',
             'Coref::CS::SetMultiGender',
             'A2T::CS::MarkTextPronCoref',
-            'Coref::RearrangeLinks retain_cataphora=1',
+#            'Coref::RearrangeLinks retain_cataphora=1',
             'Coref::DisambiguateGrammatemes',
             ;
     }

--- a/lib/Treex/Tool/Coreference/Utils.pm
+++ b/lib/Treex/Tool/Coreference/Utils.pm
@@ -44,12 +44,14 @@ sub _create_coref_graph {
     
     my $aa_graph = Graph->new;
     foreach my $anaph_id ($graph->vertices) {
-        my @anaph_expand = Treex::Core::Node::T::get_node_appos_expanded($id_to_node->{$anaph_id});
+        my $anaph = $id_to_node->{$anaph_id};
+        my @anaph_expand = $anaph->get_appos_expansion({with_appos_root => 0});
         foreach my $new_anaph (@anaph_expand) {
             $aa_graph->add_vertex($new_anaph->id);
             $id_to_node->{$new_anaph->id} = $new_anaph;
             foreach my $ante_id ($graph->successors($anaph_id)) {
-                my @ante_expand = Treex::Core::Node::T::get_node_appos_expanded($id_to_node->{$ante_id});
+                my $ante = $id_to_node->{$ante_id};
+                my @ante_expand = $ante->get_appos_expansion({with_appos_root => 0});
                 foreach my $new_ante (@ante_expand) {
                     $aa_graph->add_edge($new_anaph->id, $new_ante->id);
                     $id_to_node->{$new_anaph->id} = $new_anaph;


### PR DESCRIPTION
Coreference relation connects mentions that refer to the same discourse entity - they can be considered equivalent. The same usually holds for members of apposition, e.g. _Barack Obama, the U.S. president_. Quality of coreference resolution is never affected in such cases, no matter whether the resolver labels _Barack Obama_, or _the U.S. president_ as the antecedent. This pull request changes the way how coreference is retrieved as well as stored if any of the arguments belongs to an apposition. It requires the apposition to be represented in a Prague dependency style.

### Retrieval
If `get_coref_nodes` (or the textual or the grammatical version) is called on any node that belongs to an apposition (apposition root or a member), the call of the function is distributed on all apposition nodes. All the antecedents are collected, but only the apposition members are returned as a result. For instance, if called on an anaphor referring to the example apposition above, both _Barack Obama_ and _the U.S. president_ subtrees are returned. To enable/disable this function use the following call:
`$anaph->get_coref_nodes({appos_aware => 1/0})`
By default, the apposition-aware retrieval is enabled.

### Storing
If `add_coref_nodes` (or the textual or the grammatical version) is called on any node that belongs to an apposition, the coreference link is always made to lead from the apposition root. The same holds for the target node of the coreference link. As a result, there is never a physical link going from or to an apposition member, using this method. For the time being, the apposition-aware storing cannot be disabled.

### Questions
There are cases when leading a link to one of the members is more reasonable than to the apposition root. In a Czech example _Česko, země, která je..._, a good reason to target the relative pronoun _která_ into _země_, rather than the apposition root, is an agreement of the two aruments in gender and number. What is the most ellegant solution?

With this change, the `Tool::Coreference::Utils` and the translation scenario must have been adjusted to get more or less similar MT scores.